### PR TITLE
Add support to also take pulse data from PulsePatternDecoder devices

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,13 +7,14 @@ import pytest
 from extra_data.tests.mockdata import write_file
 from extra_data.tests.mockdata.xgm import XGM
 
-from .mockdata.timeserver import Timeserver
+from .mockdata.timeserver import Timeserver, PulsePatternDecoder
 
 
 @pytest.fixture(scope='session')
 def mock_spb_aux_run():
     sources = [
         Timeserver('SPB_RR_SYS/TSYS/TIMESERVER'),
+        PulsePatternDecoder('SPB_RR_SYS/MDL/BUNCH_PATTERN'),
         Timeserver('ODD_TIMESERVER_NAME'),
         XGM('SPB_XTD9_XGM/DOOCS/MAIN')]
 

--- a/tests/mockdata/timeserver.py
+++ b/tests/mockdata/timeserver.py
@@ -1,13 +1,15 @@
 
+import numpy as np
+
 from euxfel_bunch_pattern import DESTINATION_T4D, DESTINATION_T5D, \
-    PHOTON_LINE_DEFLECTION, PPL_BITS
+    PHOTON_LINE_DEFLECTION, PPL_BITS, is_sase, is_laser
 from extra_data.tests.mockdata.base import DeviceBase
 
 
-def _fill_bunch_pattern_table(table):
+def _fill_bunch_pattern_table(table, num_rows):
     # SASE 1
-    table[:table.shape[0]//4, 1000:1300:6] |= DESTINATION_T4D
-    table[table.shape[0]//4:, 1000:1300:12] |= DESTINATION_T4D
+    table[:num_rows//2, 1000:1300:6] |= DESTINATION_T4D
+    table[num_rows//2:, 1000:1300:12] |= DESTINATION_T4D
 
     # SASE 2
     table[:, 1500:2000:8] |= DESTINATION_T5D
@@ -21,6 +23,7 @@ def _fill_bunch_pattern_table(table):
 
 class Timeserver(DeviceBase):
     control_keys = [
+        # TODO: Value increases soon.
         ('bunchPatternTable', 'u4', (2700,)),
         ('periodActual', 'f8', ()),
         ('periodSet', 'f8', ()),
@@ -43,7 +46,8 @@ class Timeserver(DeviceBase):
 
         if self.ntrains > 0 and not self.no_ctrl_data:
             _fill_bunch_pattern_table(f[
-                f'CONTROL/{self.device_id}/bunchPatternTable/value'])
+                f'CONTROL/{self.device_id}/bunchPatternTable/value'],
+                self.ntrains)
 
     def write_instrument(self, f):
         super().write_instrument(f)
@@ -51,4 +55,38 @@ class Timeserver(DeviceBase):
         if self.nsamples > 0:
             _fill_bunch_pattern_table(f[
                 f'INSTRUMENT/{self.device_id}:outputBunchPattern/'
-                f'data/bunchPatternTable'])
+                f'data/bunchPatternTable'], self.nsamples)
+
+
+class PulsePatternDecoder(DeviceBase):
+    control_keys = sum(
+        [[(f'{loc}/pulseIds', 'i4', (2700,)), (f'{loc}/nPulses', 'i4', ())]
+         for loc in ['laser', 'maindump', 'sase1', 'sase2', 'sase3']],
+        [])
+
+    extra_run_values = [
+        ('classId', None, 'TimeServer2'),
+        ('laserSource', None, 'LP_SPB')
+    ]
+
+    def write_control(self, f):
+        super().write_control(f)
+
+        if self.ntrains > 0 and not self.no_ctrl_data:
+            table = np.zeros((self.ntrains, 2700), dtype=np.uint32)
+            _fill_bunch_pattern_table(table, self.ntrains)
+
+            grp = f[f'CONTROL/{self.device_id}']
+
+            for loc, pulse_mask in [
+                ('sase1', is_sase(table, sase=1)),
+                ('sase2', is_sase(table, sase=2)),
+                ('sase3', is_sase(table, sase=3)),
+                ('laser', is_laser(table, laser=PPL_BITS.LP_SPB))
+            ]:
+                grp[f'{loc}/nPulses/value'][:] = pulse_mask.sum(axis=1)
+                id_dset = grp[f'{loc}/pulseIds/value']
+
+                for i, mask in enumerate(pulse_mask):
+                    pulse_ids = mask.nonzero()[0]
+                    id_dset[i, :len(pulse_ids)] = pulse_ids

--- a/tests/test_components_pulses.py
+++ b/tests/test_components_pulses.py
@@ -100,6 +100,21 @@ def test_select_trains(mock_spb_aux_run):
         subpulses.timeserver['data.bunchPatternTable'])
 
 
+def test_get_pulse_mask(mock_spb_aux_run):
+    run = RunDirectory(mock_spb_aux_run).select('SPB*')
+    pulses = XrayPulses(run)
+
+    mask = XrayPulses(run).get_pulse_mask()
+    assert mask.dims == ('trainId', 'pulseId')
+    assert mask[1000:1300:6].all()
+
+    mask = XrayPulses(run, sase=2).get_pulse_mask()
+    assert mask[1500:2000:8].all()
+
+    assert XrayPulses(run, sase=2).get_pulse_mask(labelled=False) \
+        [1500:2000:8].all()
+
+
 def test_is_constant_pattern(mock_spb_aux_run):
     run = RunDirectory(mock_spb_aux_run).select('SPB*')
     pulses = XrayPulses(run)

--- a/tests/test_components_pulses.py
+++ b/tests/test_components_pulses.py
@@ -9,6 +9,14 @@ from extra.data import RunDirectory, SourceData, KeyData, by_id
 from extra.components import XrayPulses, OpticalLaserPulses
 
 
+pattern_sources = dict(
+    argvalues=['SPB_RR_SYS/TSYS/TIMESERVER',
+               'SPB_RR_SYS/TSYS/TIMESERVER:outputBunchPattern',
+               'SPB_RR_SYS/MDL/BUNCH_PATTERN'],
+    ids=['timeserver-control', 'timeserver-instrument', 'ppdecoder']
+)
+
+
 def assert_equal_sourcedata(sd1, sd2):
     assert isinstance(sd1, SourceData)
     assert isinstance(sd2, SourceData)
@@ -100,32 +108,35 @@ def test_select_trains(mock_spb_aux_run):
         subpulses.timeserver['data.bunchPatternTable'])
 
 
-def test_get_pulse_mask(mock_spb_aux_run):
-    run = RunDirectory(mock_spb_aux_run).select('SPB*')
-    pulses = XrayPulses(run)
+@pytest.mark.parametrize('source', **pattern_sources)
+def test_get_pulse_mask(mock_spb_aux_run, source):
+    run = RunDirectory(mock_spb_aux_run)
+    pulses = XrayPulses(run, source=source)
 
-    mask = XrayPulses(run).get_pulse_mask()
+    mask = XrayPulses(run, source=source).get_pulse_mask()
     assert mask.dims == ('trainId', 'pulseId')
     assert mask[1000:1300:6].all()
 
-    mask = XrayPulses(run, sase=2).get_pulse_mask()
+    mask = XrayPulses(run, source=source, sase=2).get_pulse_mask()
     assert mask[1500:2000:8].all()
 
-    assert XrayPulses(run, sase=2).get_pulse_mask(labelled=False) \
-        [1500:2000:8].all()
+    assert XrayPulses(run, source=source, sase=2).get_pulse_mask(
+        labelled=False)[1500:2000:8].all()
 
 
-def test_is_constant_pattern(mock_spb_aux_run):
-    run = RunDirectory(mock_spb_aux_run).select('SPB*')
-    pulses = XrayPulses(run)
+@pytest.mark.parametrize('source', **pattern_sources)
+def test_is_constant_pattern(mock_spb_aux_run, source):
+    run = RunDirectory(mock_spb_aux_run)
+    pulses = XrayPulses(run, source=source)
 
     assert not pulses.is_constant_pattern()
     assert pulses.select_trains(np.s_[:50]).is_constant_pattern()
 
 
-def test_get_pulse_counts(mock_spb_aux_run):
-    run = RunDirectory(mock_spb_aux_run).select('SPB*')
-    pulses = XrayPulses(run)
+@pytest.mark.parametrize('source', **pattern_sources)
+def test_get_pulse_counts(mock_spb_aux_run, source):
+    run = RunDirectory(mock_spb_aux_run)
+    pulses = XrayPulses(run, source=source)
 
     # Test labelled.
     counts = pulses.get_pulse_counts(labelled=True)
@@ -137,23 +148,27 @@ def test_get_pulse_counts(mock_spb_aux_run):
     np.testing.assert_equal(pulses.get_pulse_counts(labelled=False), counts)
 
     # Check different SASE.
-    counts = XrayPulses(run, sase=2).get_pulse_counts()
+    counts = XrayPulses(run, source=source, sase=2).get_pulse_counts()
     assert (counts.index == run.train_ids).all()
     assert (counts == 63).all()
 
 
-def test_peek_pulse_ids(mock_spb_aux_run):
+@pytest.mark.parametrize('source', **pattern_sources)
+def test_peek_pulse_ids(mock_spb_aux_run, source):
     run = RunDirectory(mock_spb_aux_run).select('SPB*')
 
-    np.testing.assert_equal(XrayPulses(run).peek_pulse_ids(),
-                            np.r_[1000:1300:6])
-    np.testing.assert_equal(XrayPulses(run, sase=2).peek_pulse_ids(),
-                            np.r_[1500:2000:8])
+    np.testing.assert_equal(
+        XrayPulses(run, source=source).peek_pulse_ids(),
+        np.r_[1000:1300:6])
+    np.testing.assert_equal(
+        XrayPulses(run, source=source, sase=2).peek_pulse_ids(),
+        np.r_[1500:2000:8])
 
 
-def test_get_pulse_ids(mock_spb_aux_run):
-    run = RunDirectory(mock_spb_aux_run).select('SPB*')
-    pulses = XrayPulses(run)
+@pytest.mark.parametrize('source', **pattern_sources)
+def test_get_pulse_ids(mock_spb_aux_run, source):
+    run = RunDirectory(mock_spb_aux_run)
+    pulses = XrayPulses(run, source=source)
 
     # Test labelled.
     pids = pulses.get_pulse_ids()
@@ -167,9 +182,10 @@ def test_get_pulse_ids(mock_spb_aux_run):
     np.testing.assert_equal(pulses.get_pulse_ids(labelled=False), pids)
 
 
-def test_search_pulse_patterns(mock_spb_aux_run):
-    run = RunDirectory(mock_spb_aux_run).select('SPB*')
-    pulses = XrayPulses(run)
+@pytest.mark.parametrize('source', **pattern_sources)
+def test_search_pulse_patterns(mock_spb_aux_run, source):
+    run = RunDirectory(mock_spb_aux_run)
+    pulses = XrayPulses(run, source=source)
 
     patterns = pulses.search_pulse_patterns()
     assert len(patterns) == 2
@@ -179,9 +195,10 @@ def test_search_pulse_patterns(mock_spb_aux_run):
     np.testing.assert_equal(patterns[1][1], np.r_[1000:1300:12])
 
 
-def test_trains(mock_spb_aux_run):
-    run = RunDirectory(mock_spb_aux_run).select('SPB*')
-    pulses = XrayPulses(run)
+@pytest.mark.parametrize('source', **pattern_sources)
+def test_trains(mock_spb_aux_run, source):
+    run = RunDirectory(mock_spb_aux_run)
+    pulses = XrayPulses(run, source=source)
 
     for ref_tid, (tid, pids) in zip(run.train_ids, pulses.trains()):
         assert ref_tid == tid
@@ -192,14 +209,18 @@ def test_trains(mock_spb_aux_run):
             np.testing.assert_equal(pids, np.r_[1000:1300:12])
 
 
-def test_optical_laser(mock_spb_aux_run):
-    run = RunDirectory(mock_spb_aux_run).select('SPB*')
+@pytest.mark.parametrize('source', **pattern_sources)
+def test_optical_laser_basic(mock_spb_aux_run, source):
+    run = RunDirectory(mock_spb_aux_run)
+    pulses = OpticalLaserPulses(run, source=source)
 
-    # Regular usage.
-    pulses = OpticalLaserPulses(run)
     assert pulses.ppl_seed == PPL_BITS.LP_SPB
     assert (pulses.get_pulse_counts() == 50).all()
     assert (pulses.get_pulse_ids(labelled=False)[:50] == np.r_[0:300:6]).all()
+
+
+def test_optical_laser_specials(mock_spb_aux_run):
+    run = RunDirectory(mock_spb_aux_run).select('SPB*')
 
     # Different laser seed by enum
     pulses = OpticalLaserPulses(run, ppl_seed=PPL_BITS.LP_SQS)
@@ -211,7 +232,6 @@ def test_optical_laser(mock_spb_aux_run):
     assert pulses.ppl_seed == PPL_BITS.LP_SASE2
     assert (pulses.get_pulse_counts() == 0).all()
 
-
     # Full run with two timeservers
     run = RunDirectory(mock_spb_aux_run)
 
@@ -220,6 +240,14 @@ def test_optical_laser(mock_spb_aux_run):
 
     OpticalLaserPulses(run, source='ODD_TIMESERVER_NAME')
 
+    # Explicit PPL seeds with pulse pattern decoder.
+    OpticalLaserPulses(run, source='SPB_RR_SYS/MDL/BUNCH_PATTERN',
+                       ppl_seed='SPB')
+
+    with pytest.raises(ValueError):
+        OpticalLaserPulses(run, source='SPB_RR_SYS/MDL/BUNCH_PATTERN',
+                           ppl_seed='FXE')
+
     # Only odd timeserver now
     run = run.select('ODD_TIMESERVER_NAME*')
 
@@ -227,3 +255,17 @@ def test_optical_laser(mock_spb_aux_run):
         OpticalLaserPulses(run)
 
     OpticalLaserPulses(run, ppl_seed=PPL_BITS.LP_SPB)
+
+
+def test_ppdecoder(mock_spb_aux_run):
+    run = RunDirectory(mock_spb_aux_run)
+    pulses = XrayPulses(run, source='SPB_RR_SYS/MDL/BUNCH_PATTERN')
+
+    assert_equal_sourcedata(pulses.pulse_pattern_decoder,
+                            run['SPB_RR_SYS/MDL/BUNCH_PATTERN'])
+
+    with pytest.raises(ValueError):
+        pulses.timeserver
+
+    with pytest.raises(ValueError):
+        pulses.bunch_pattern_table

--- a/tests/test_components_pulses.py
+++ b/tests/test_components_pulses.py
@@ -66,7 +66,7 @@ def test_init(mock_spb_aux_run):
         XrayPulses(run)
 
     # Pick one specifically.
-    pulses = XrayPulses(run, timeserver='ODD_TIMESERVER_NAME')
+    pulses = XrayPulses(run, source='ODD_TIMESERVER_NAME')
     assert_equal_sourcedata(
         pulses.timeserver,
         run['ODD_TIMESERVER_NAME'])
@@ -203,7 +203,7 @@ def test_optical_laser(mock_spb_aux_run):
     with pytest.raises(ValueError):
         OpticalLaserPulses(run)
 
-    OpticalLaserPulses(run, timeserver='ODD_TIMESERVER_NAME')
+    OpticalLaserPulses(run, source='ODD_TIMESERVER_NAME')
 
     # Only odd timeserver now
     run = run.select('ODD_TIMESERVER_NAME*')


### PR DESCRIPTION
While preparing a demo for FXE, I noticed the timeserver is never saved to file at this instrument, there's not even a config group for it. In principle most of the functionality of this component can also be exposed from this information, so I figured it may make sense to offer support for it as well. That has the upside that in the future, users don't even need to care which kind of pulse-pattern-carrying-device is used.

Unfortunately it did make the interface a bit more messy and required a somewhat arbitrary internal interface to abstract between the two, but it also forced me to fix a potential bug in `PulsePattern.peek_pulse_ids()` when the first train actually contains no pulse pattern data.

Marked as draft since it's still missing tests and some more docs.

@JamesWrigley @takluyver 