### PR TITLE
Scantool compatibility and pretty-printing

### DIFF
--- a/src/extra/components/scantool.py
+++ b/src/extra/components/scantool.py
@@ -47,13 +47,26 @@ class Scantool:
 
         values = run.get_run_values(src)
 
+        def get_first_value(keys):
+            for key in keys:
+                if key in values:
+                    return values[key]
+
+            raise KeyError(f"Could not find any of these RUN section keys: {', '.join(keys)}")
+
+        # These are a list of possible property names for different versions of
+        # the scantool. So far we've only seen the names being different, the
+        # values are the same.
+        acquisition_time_keys = ["deviceEnv.acquisitionTime.value", "acquisitionTime.value"]
+        active_motors_keys = ["deviceEnv.activeMotors.value", "activeMotors.value"]
+
         # Get scan metadata and list of motors
         self._source_name = src
         self._source = run[src]
         self._active = self.source["isMoving"].ndarray().any()
         self._scan_type = values["scanEnv.scanType.value"]
-        self._acquisition_time = values["deviceEnv.acquisitionTime.value"]
-        self._motors = [x.decode() for x in values["deviceEnv.activeMotors.value"] if len(x) > 0]
+        self._acquisition_time = get_first_value(acquisition_time_keys)
+        self._motors = [x.decode() for x in get_first_value(active_motors_keys) if len(x) > 0]
 
         # The deviceEnv.activeMotors property stores the motor aliases,
         # but we can try to get the actual device names from the

--- a/src/extra/components/scantool.py
+++ b/src/extra/components/scantool.py
@@ -161,9 +161,8 @@ class Scantool:
             compact (bool): Whether to print the information in a compact 1-line format or a
                 multi-line format.
         """
-        if not self.active:
-            device = " " if compact else f" ({self.source_name}) "
-            return f"Scantool{device}not active."
+        if compact and not self.active:
+            return f"Scantool ({self.source_name}) not active."
         else:
             if compact:
                 motor_info = [self._motor_fmt(name, compact=True) for name in self.motors]
@@ -177,6 +176,11 @@ class Scantool:
 
                 info.extend(["  " + self._motor_fmt(name, compact=False)
                              for name in self.motors])
+
+                if not self.active:
+                    info = ["Note: the scantool was not active for this run!",
+                            ""] + info
+
                 return "\n".join(info)
 
     def __repr__(self):

--- a/tests/test_components_scantool.py
+++ b/tests/test_components_scantool.py
@@ -60,3 +60,14 @@ def test_scantool():
         scantool = Scantool(mock_run)
     assert scantool.scan_type in str(scantool)
     assert scantool.scan_type in repr(scantool)
+
+    # Test compatibility with Karabacon 3.0.7-2.16.2, which is an older version
+    # still used at FXE. In this version the activeMotors and acquisitionTime
+    # are stored as first-level properties rather than being under deviceEnv.
+    mock_run_values["acquisitionTime.value"] = mock_run_values["deviceEnv.acquisitionTime.value"]
+    mock_run_values["activeMotors.value"] = mock_run_values["deviceEnv.activeMotors.value"]
+    del mock_run_values["deviceEnv.acquisitionTime.value"]
+    del mock_run_values["deviceEnv.activeMotors.value"]
+
+    # This shouldn't throw an exception
+    scantool = Scantool(mock_run)


### PR DESCRIPTION
Two changes:
- Fixed compatibility for FXE's version of the scantool in af90d66.
- Made the pretty-printing prettier in c322477. It might be nice to see the scantool configuration even when it's not active (e.g. in a demo :wink: ).