### PR TITLE
Add PumpProbePulses for combined FEL/PPL pulse patterns

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,6 +18,7 @@
 
 Added:
 
+- [PumpProbePulses][extra.components.PumpProbePulses] to combine X-ray and optical laser pulses in a single pattern (!24).
 - The [Scan][extra.components.Scan] component to automatically detect steps
   within a motor scan (!4).
 - [DldPulses][extra.components.DldPulses] to access pulse information saved during delay line detector event reconstruction (!42).

--- a/docs/components/pulse-patterns.md
+++ b/docs/components/pulse-patterns.md
@@ -3,3 +3,5 @@
 ::: extra.components.OpticalLaserPulses
 
 ::: extra.components.DldPulses
+
+::: extra.components.PumpProbePulses

--- a/src/extra/components/__init__.py
+++ b/src/extra/components/__init__.py
@@ -1,4 +1,4 @@
 
 from .scantool import Scantool  # noqa
-from .pulses import XrayPulses, OpticalLaserPulses, DldPulses  # noqa
-from .scan import Scan
+from .pulses import XrayPulses, OpticalLaserPulses, PumpProbePulses, DldPulses  # noqa
+from .scan import Scan  # noqa

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ from .mockdata.timeserver import Timeserver, PulsePatternDecoder
 
 
 @pytest.fixture(scope='session')
-def mock_spb_aux_run():
+def mock_spb_aux_directory():
     sources = [
         Timeserver('SPB_RR_SYS/TSYS/TIMESERVER'),
         PulsePatternDecoder('SPB_RR_SYS/MDL/BUNCH_PATTERN'),
@@ -23,4 +23,9 @@ def mock_spb_aux_run():
 
     with TemporaryDirectory() as td:
         write_file(Path(td) / 'RAW-R0001-DA01-S00000.h5', sources, 100)
-        yield RunDirectory(td)
+        yield td
+
+
+@pytest.fixture(scope='function')
+def mock_spb_aux_run(mock_spb_aux_directory):
+    yield RunDirectory(mock_spb_aux_directory)


### PR DESCRIPTION
The third component in the mix for pump-probe experiments 🔦 

* Combines FEL and PPL pulses into a single linear pattern
* Move PPL pulses to their _true_ location by fixed bunch table position or relative bunch table/pulse distance to first FEL pulse 
* Extends the `MultiIndex` by two boolean fields `fel` and `ppl` to distinguish between respective shots