### PR TITLE
Move the __repr__() logic into .info()

### DIFF
--- a/src/extra/components/scantool.py
+++ b/src/extra/components/scantool.py
@@ -6,15 +6,10 @@ from extra_data import SourceData
 class Scantool:
     """Interface for the European XFEL scantool (Karabacon).
 
-    Note that the [repr][] function for this class uses
-    [Scantool.format()][extra.components.Scantool.format]
-    internally, so evaluating a `Scantool` object in a Jupyter notebook
-    cell will print the scantool configuration:
-
     ```python
             -----------------------------------------------------------
     In [1]: |scantool = Scantool(run)                                 |
-            |scantool                                                 |
+            |scantool.info()                                          |
             -----------------------------------------------------------
     Out[1]: Scantool (MID_RR_SYS/MDL/KARABACON) configuration:
               Scan type: dscan
@@ -167,7 +162,11 @@ class Scantool:
             else:
                 return f"{name} ({self.motor_devices[name]}): {motion_info}"
 
-    def format(self, compact=True):
+    def info(self, compact=False):
+        """Print information about the scantool from [Scantool.format()][extra.components.Scantool.format]."""
+        print(self.format(compact=compact))
+
+    def format(self, compact=False):
         """Format information about the scantool as a string.
 
         Args:
@@ -197,7 +196,10 @@ class Scantool:
                 return "\n".join(info)
 
     def __repr__(self):
-        return self.format(compact=False)
+        if len(self.motors) == 1:
+            motor_str = self.motors[0]
+        else:
+            motor_str = f"{len(self.motors)} motors"
 
-    def __str__(self):
-        return self.format(compact=True)
+        active_str = "" if self.active else " (inactive)"
+        return f"<Scantool {self.source_name}{active_str} configured for {self.scan_type} over {motor_str}>"

--- a/tests/test_components_scantool.py
+++ b/tests/test_components_scantool.py
@@ -42,8 +42,6 @@ def test_scantool():
     mock_source["isMoving"].ndarray.return_value = np.zeros(10, dtype=np.uint8)
     scantool = Scantool(mock_run)
     assert not scantool.active
-    assert "not active" in str(scantool)
-    assert "not active" in repr(scantool)
 
     # Now with a run where it is active
     mock_source["isMoving"].ndarray.return_value = np.ones(10, dtype=np.uint8)
@@ -51,15 +49,11 @@ def test_scantool():
     assert scantool.active
     assert scantool.motors == ["polarizer_theta", "Theta_ana"]
     assert scantool.motor_devices is not None
-    assert scantool.scan_type in str(scantool)
-    assert scantool.scan_type in repr(scantool)
 
     # And with a run with an unsupported actualConfiguration format
     mock_run_values["actualConfiguration.value"] = "--- Motors:['MID_AUXT1_UPP/MOTOR/R1:default', 'MID_EXP_UPP/MOTOR/T7:default']"
     with pytest.warns():
         scantool = Scantool(mock_run)
-    assert scantool.scan_type in str(scantool)
-    assert scantool.scan_type in repr(scantool)
 
     # Test compatibility with Karabacon 3.0.7-2.16.2, which is an older version
     # still used at FXE. In this version the activeMotors and acquisitionTime
@@ -71,3 +65,8 @@ def test_scantool():
 
     # This shouldn't throw an exception
     scantool = Scantool(mock_run)
+
+    # Smoke tests
+    scantool.info()
+    scantool.format()
+    repr(scantool)


### PR DESCRIPTION
This hasn't happened yet, but one could imagine doing something like putting one of these objects into a list or something and __repr__() completely breaking the pretty-printing. Instead we now recommend using .info() like with DataCollection's.