### PR TITLE
Add get_version.py to excluded package data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,9 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools.dynamic]
 version = { attr = "get_version.version" }
 
+[tool.setuptools.exclude-package-data]
+"*" = ["get_version.py"]
+
 [project]
 name = "euxfel-EXtra"
 dynamic = ["version"]


### PR DESCRIPTION
Did not occur to me that `get_version.py` would be included in global namespace since it is in `src/get_version.py`.

PR excludes the file from being packaged.