### PR TITLE
Update the changelog

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,15 +2,32 @@
 
 # Changelog
 
+## Unreleased
+
+!!! note
+    All of the changes here are deployed to our current environment, even though
+    a release hasn't been made for them yet. If you want to have these updates
+    in a personal environment you'll need to install the package from git.
+
+    ```bash title="Installation command"
+    pip install git+https://github.com/European-XFEL/EXtra.git
+    ```
+
+Changed:
+
+- [Scantool][extra.components.Scantool]'s `__repr__()` functionality to print
+  information was moved to [Scantool.info()][extra.components.Scantool.info]
+  (!29).
+
 ## 2023.2
 The initial release! :tada: :sparkles:
 
 Added:
 
-- A [Scantool](components.md#extra.components.Scantool) component for the EuXFEL scantool, in !2.
+- A [Scantool][extra.components.Scantool] component for the EuXFEL scantool, in !2.
 - Components for extracting the X-ray and optical laser pulse patterns:
-  [XrayPulses](components.md#extra.components.XrayPulses) and
-  [OpticalLaserPulses](components.md#extra.components.OpticalLaserPulses) in !5.
+  [XrayPulses][extra.components.XrayPulses] and
+  [OpticalLaserPulses][extra.components.OpticalLaserPulses] in !5.
 - A collection of [utility](utilities.md) functions.
 - Sub-modules to forward [EXtra-data](reading-data.md),
   [EXtra-geom](detector-geometry.md), and [karabo-bridge-py](karabo-bridge.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ theme:
     text: Open Sans
   features:
     - content.code.annotate
+    - content.code.copy
     - navigation.instant
 
 nav:


### PR DESCRIPTION
- Replace links to API sections with links to the classes themselves.
- Add an 'Unreleased' section to the changelog.

Maybe we could try updating the changelog in any PRs that are noteworthy, instead of going through commits before a release? I think that would be particularly useful given extra's rolling release model.