### PR TITLE
Re-implement PulsePattern interface on top of labelled pulse IDs rather than mask

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,9 @@ Added:
 
 Changed:
 
+- All methods in [XrayPulses][extra.components.XrayPulses] and
+  [OpticalLaserPulses][extra.components.OpticalLaserPulses] now support labelled results
+  and default to it.
 - [Scantool][extra.components.Scantool]'s `__repr__()` functionality to print
   information was moved to [Scantool.info()][extra.components.Scantool.info]
   (!29).


### PR DESCRIPTION
Turned out the original design on top of a pulse mask (boolean array whether there's a pulse in any bunch table position) was a somewhat poor choice, likely biased by initially only using data from the timeserver device. It became increasingly messy and complex trying to address the open points in https://github.com/European-XFEL/EXtra/pull/24.

Instead I doubled down on basing everything on top of `pandas` series with `pd.MultIndex` instead. This way, the entire interface can be implemented through ~~`._get_train_ids()` and~~ `._get_pulse_ids()`, which fits much better with some future components I have lined up around non-timeserver pulse data. Pretty much all methods are faster now (in particular `.is_constant_pattern()`!) across small and large runs with the exception of `.get_pulse_mask()`, which seems unlikely to be used much.

Also found some missing test cases and homogenized interface options. As a bonus, the entire public API still remains unchanged apart from additional options 🎉 

This PR only changes what's already merged, I will update https://github.com/European-XFEL/EXtra/pull/24 afterwards.