### PR TITLE
Add DldPulses interface for pulse information in reconstructed DLD data

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,6 +18,7 @@
 
 Added:
 
+- [DldPulses][extra.components.DldPulses] to access pulse information saved during delay line detector event reconstruction (!42).
 - The helper function [imshow2][extra.utils.imshow2] to provide good defaults when
   plotting images (!38).
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -8,3 +8,5 @@ easier.
 ::: extra.components.XrayPulses
 
 ::: extra.components.OpticalLaserPulses
+
+::: extra.components.DldPulses

--- a/src/extra/components/__init__.py
+++ b/src/extra/components/__init__.py
@@ -1,3 +1,3 @@
 
 from .scantool import Scantool  # noqa
-from .pulses import XrayPulses, OpticalLaserPulses  # noqa
+from .pulses import XrayPulses, OpticalLaserPulses, DldPulses  # noqa


### PR DESCRIPTION
First `PulsePattern` implementation based on the new and simpler interface.

The offline calibration based REMI/DLD reconstruction adds pulse information to the output files that *may* be different than the one obtained from timeserver data due to particular configurations chosen for reconstruction at the time. This compoent allows to read this data and expose it via the very same interface.