### PR TITLE
Activate env modules in install script

### DIFF
--- a/docs/install-extra.sh
+++ b/docs/install-extra.sh
@@ -53,6 +53,7 @@ function check_and_install()
 }
 
 # Always install into the current environment
+source /usr/share/Modules/init/bash
 module load exfel exfel-python
 
 check_and_install


### PR DESCRIPTION
Adds `source /usr/share/Modules/init/bash` to the script.

Required since module commands not available in cron shell environment.