### PR TITLE
Scan bugs

### DIFF
--- a/src/extra/components/scan.py
+++ b/src/extra/components/scan.py
@@ -199,7 +199,7 @@ class Scan:
                          i * step_size)
                  for i in range(n_steps)]
 
-        motor = np.concatenate(steps)
+        motor = np.concatenate(steps, dtype=np.float64)
 
         from xarray import DataArray
         motor = DataArray(motor,
@@ -339,10 +339,11 @@ class Scan:
         # Detect backlash at the beginning by comparing the step direction of
         # the first and second steps. If there's backlash they're typically not
         # the same, so we remove the first step if so.
-        first_step = steps[1][0] - steps[0][0]
-        second_step = steps[2][0] - steps[1][0]
-        if np.sign(first_step) != np.sign(second_step):
-            del steps[0]
+        if len(steps) >= 3:
+            first_step = steps[1][0] - steps[0][0]
+            second_step = steps[2][0] - steps[1][0]
+            if np.sign(first_step) != np.sign(second_step):
+                del steps[0]
 
         return steps
 

--- a/src/extra/components/scan.py
+++ b/src/extra/components/scan.py
@@ -242,6 +242,15 @@ class Scan:
         if len(diff_filt) == 0:
             return None
 
+        # If all the diff's sum to 0 then taking the weighted average will fail
+        # later with a ZeroDivisionError. This only happens in very specific
+        # situations where the motor value is jittering between two values such
+        # that the diffs have a constant magnitude `C`and jump between +C and
+        # -C. And if there are equal counts of +C and -C then the total sum will
+        # be 0.
+        if np.sum(diff_filt) == 0:
+            return None
+
         # Take the average of the diffs, weighted by their value
         # to try to ignore jitter or drift within the steps, which
         # will show up as lots of little diffs.

--- a/tests/test_components_scan.py
+++ b/tests/test_components_scan.py
@@ -46,6 +46,12 @@ def test_scan(mock_spb_aux_run):
     not_a_scan = Scan(motor)
     assert len(not_a_scan.positions) == 0
 
+    # Test behaviour with a noisy motor, which will initially be detected as
+    # having a single step, and that single step should be filtered out such
+    # that no steps are detected.
+    motor += np.random.rand(len(motor)) * 0.1
+    assert len(Scan(motor).steps) == 0
+
     # Smoke tests
     s.plot()
     s._plot_resolution_data()

--- a/tests/test_components_scan.py
+++ b/tests/test_components_scan.py
@@ -52,6 +52,22 @@ def test_scan(mock_spb_aux_run):
     motor += np.random.rand(len(motor)) * 0.1
     assert len(Scan(motor).steps) == 0
 
+    # Test an edge case with a motor that's jittering between two values (see
+    # the ZeroDivisionError check in Scan._guess_resolution()). This is somewhat
+    # finicky to test because we have to make sure that the *sum* of a bunch of
+    # floats is exactly 0, which is tricky because of floating point error. We
+    # force this to happen by summing only a few values to limit the error.
+    motor_slice = motor[:9]
+    # The length of the motor array must be odd, because then we'll have an even
+    # number of diffs to sum (to 0).
+    assert len(motor_slice) == 9
+    motor_slice[1::2] = -1
+    motor_slice[::2] = 1
+    # Make sure that the fake motor has the right values
+    assert np.sum(np.diff(motor_slice)) == 0
+    # This should not throw, and should not detect any steps
+    assert len(Scan(motor_slice).steps) == 0
+
     # Smoke tests
     s.plot()
     s._plot_resolution_data()


### PR DESCRIPTION
Fixes two bugs I found (see the commits for details):
- Backlash detection would sometimes cause exceptions on scans with noisy motors (3a35fe8)
- Sometimes motors will jitter between two specific values, which can cause `ZeroDivisionError`'s (57e596e)