### PR TITLE
Fix handling of trains without pulses

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,9 @@ def mock_spb_aux_directory():
         Timeserver('SPB_RR_SYS/TSYS/TIMESERVER'),
         PulsePatternDecoder('SPB_RR_SYS/MDL/BUNCH_PATTERN'),
         Timeserver('ODD_TIMESERVER_NAME'),
+        PulsePatternDecoder('TRAIN_LESS_DECODER', no_ctrl_data=True),
+        Timeserver('TRAIN_LESS_TIMESERVER', no_ctrl_data=True, nsamples=0),
+        Timeserver('PULSE_LESS_TIMESERVER', no_pulses=True),
         XGM('SPB_XTD9_XGM/DOOCS/MAIN'),
         Motor("MOTOR/MCMOTORYFACE")]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,21 @@ from .mockdata.timeserver import Timeserver, PulsePatternDecoder
 
 @pytest.fixture(scope='session')
 def mock_spb_aux_directory():
+    """Mock run directory with SPB auxiliary sources.
+
+    Pulse pattern per train:
+        - 0:10, no pulses
+        - SA1
+            - 10:50, 50 pulses at 1000:1300:6
+            - 50:100, 25 pulses at 1000:1300:12
+        - SA2
+            - 10:100, 62 pulses at 1500:2000:8
+        - SA3
+            - 10:100, 1 pulse at 200
+        - LP_SPB
+            - 10:100, 50 pulses at 0:300:6
+    """
+
     sources = [
         Timeserver('SPB_RR_SYS/TSYS/TIMESERVER'),
         PulsePatternDecoder('SPB_RR_SYS/MDL/BUNCH_PATTERN'),

--- a/tests/test_components_pulses.py
+++ b/tests/test_components_pulses.py
@@ -95,9 +95,23 @@ def test_init(mock_spb_aux_run):
         XrayPulses(run_no_ts, sase=1)
 
 
+@pytest.mark.parametrize(
+    'source',
+    argvalues=['TRAIN_LESS_TIMESERVER',
+               'TRAIN_LESS_TIMESERVER:outputBunchPattern',
+               'TRAIN_LESS_DECODER'],
+    ids=['timeserver-control', 'timeserver-instrument', 'ppdecoder']
+)
+def test_no_trains(mock_spb_aux_run, source):
+    # Test with entirely empty data.
+    pulses = XrayPulses(mock_spb_aux_run, source)
+    assert pulses.get_pulse_ids().empty
+    assert pulses.get_pulse_counts().empty
+
+
 def test_select_trains(mock_spb_aux_run):
-    run = mock_spb_aux_run.select('SPB*')
-    pulses = XrayPulses(run)
+    run = mock_spb_aux_run
+    pulses = XrayPulses(run.select('SPB*'))
 
     subrun = run.select_trains(np.s_[:20])
     subpulses = pulses.select_trains(np.s_[:20])
@@ -109,6 +123,10 @@ def test_select_trains(mock_spb_aux_run):
         subpulses.bunch_pattern_table,
         subpulses.timeserver['data.bunchPatternTable'])
 
+    # Select down to trains with no pulses.
+    pulses = XrayPulses(run, 'PULSE_LESS_TIMESERVER')
+    pulses.select_trains(np.s_[:20])
+
 
 @pytest.mark.parametrize('source', **pattern_sources)
 def test_get_pulse_mask(mock_spb_aux_run, source):
@@ -119,13 +137,15 @@ def test_get_pulse_mask(mock_spb_aux_run, source):
     assert mask.dims == ('trainId', 'pulseId')
     assert (mask.coords['trainId'] == run.train_ids).all()
     assert (mask.coords['pulseId'] == np.arange(mask.shape[1])).all()
-    assert mask[1000:1300:6].all()
+    assert not mask[:10, :].any()
+    assert mask[10:50, 1000:1300:6].all()
+    assert mask[10:, 1000:1300:12].all()
 
     mask = XrayPulses(run, source=source, sase=2).get_pulse_mask()
-    assert mask[1500:2000:8].all()
+    assert mask[10:, 1500:2000:8].all()
 
     assert XrayPulses(run, source=source, sase=2).get_pulse_mask(
-        labelled=False)[1500:2000:8].all()
+        labelled=False)[10:, 1500:2000:8].all()
 
 
 @pytest.mark.parametrize('source', **pattern_sources)
@@ -145,7 +165,8 @@ def test_get_pulse_counts(mock_spb_aux_run, source):
     # Test labelled.
     counts = pulses.get_pulse_counts(labelled=True)
     assert (counts.index == run.train_ids).all()
-    assert (counts.iloc[:50] == 50).all()
+    assert (counts.iloc[:10] == 0).all()
+    assert (counts.iloc[10:50] == 50).all()
     assert (counts.iloc[50:] == 25).all()
 
     # Test unlabelled.
@@ -154,25 +175,30 @@ def test_get_pulse_counts(mock_spb_aux_run, source):
     # Test different SASE.
     counts = XrayPulses(run, source=source, sase=2).get_pulse_counts()
     assert (counts.index == run.train_ids).all()
-    assert (counts == 63).all()
+    assert (counts[:10] == 0).all()
+    assert (counts[10:] == 63).all()
 
 
 @pytest.mark.parametrize('source', **pattern_sources)
 def test_peek_pulse_ids(mock_spb_aux_run, source):
-    run = mock_spb_aux_run.select('SPB*')
-    pulses = XrayPulses(run, source=source)
+    run_full = mock_spb_aux_run.select('SPB*')
+    run_beam = mock_spb_aux_run.select('SPB*').select_trains(np.s_[10:])
 
-    # Test labelled.
+    # Test full run with empty pulses in the beginning.
+    pulses = XrayPulses(run_full, source=source)
+    assert pulses.peek_pulse_ids().empty
+    assert pulses.peek_pulse_ids(labelled=False).size == 0
+
+    # Test run starting at train with pulses.
+    pulses = XrayPulses(run_beam, source=source)
     pids = pulses.peek_pulse_ids()
     np.testing.assert_equal(pids.index, np.arange(len(pids)))
     np.testing.assert_equal(pids, np.r_[1000:1300:6])
-
-    # Test unlabelled.
     np.testing.assert_equal(pulses.peek_pulse_ids(labelled=False), pids)
 
     # Test different SASE.
     np.testing.assert_equal(
-        XrayPulses(run, source=source, sase=2).peek_pulse_ids(),
+        XrayPulses(run_beam, source=source, sase=2).peek_pulse_ids(),
         np.r_[1500:2000:8])
 
 
@@ -183,10 +209,10 @@ def test_get_pulse_ids(mock_spb_aux_run, source):
 
     # Test labelled.
     pids = pulses.get_pulse_ids()
-    assert len(pids) == 3750
-    np.testing.assert_equal(pids[:, 0].index, np.array(run.train_ids))
-    np.testing.assert_equal(pids[run.train_ids[0], :].index, np.r_[:50])
-    np.testing.assert_equal(pids[run.train_ids[0], :], np.r_[1000:1300:6])
+    assert len(pids) == 3250
+    np.testing.assert_equal(pids[:, 0].index, np.array(run.train_ids[10:]))
+    np.testing.assert_equal(pids[run.train_ids[10], :].index, np.r_[:50])
+    np.testing.assert_equal(pids[run.train_ids[10], :], np.r_[1000:1300:6])
     np.testing.assert_equal(pids[run.train_ids[50], :], np.r_[1000:1300:12])
 
     # Test unlabelled.
@@ -203,26 +229,26 @@ def test_get_pulse_index(mock_spb_aux_run, source):
 
     train_ids = index.get_level_values(0)
     np.testing.assert_equal(
-        train_ids[:2500], np.repeat(run.train_ids[:50], 50))
+        train_ids[:2000], np.repeat(run.train_ids[10:50], 50))
     np.testing.assert_equal(
-        train_ids[2500:], np.repeat(run.train_ids[50:], 25))
+        train_ids[2000:], np.repeat(run.train_ids[50:], 25))
 
     pulse_ids = index.get_level_values(1)
     np.testing.assert_equal(
-        pulse_ids[:2500], np.tile(np.r_[1000:1300:6], 50))
+        pulse_ids[:2000], np.tile(np.r_[1000:1300:6], 40))
     np.testing.assert_equal(
-        pulse_ids[2500:], np.tile(np.r_[1000:1300:12], 50))
+        pulse_ids[2000:], np.tile(np.r_[1000:1300:12], 50))
 
     pulse_indices = pulses.get_pulse_index('pulseIndex').get_level_values(1)
-    np.testing.assert_equal(pulse_indices[:2500], np.tile(np.r_[:50], 50))
-    np.testing.assert_equal(pulse_indices[2500:], np.tile(np.r_[:25], 50))
+    np.testing.assert_equal(pulse_indices[:2000], np.tile(np.r_[:50], 40))
+    np.testing.assert_equal(pulse_indices[2000:], np.tile(np.r_[:25], 50))
 
     times = pulses.get_pulse_index('time').get_level_values(1)
     rate = pulses.bunch_repetition_rate
     np.testing.assert_allclose(
-        times[:2500], np.tile((np.r_[1000:1300:6] - 1000) / rate, 50))
+        times[:2000], np.tile((np.r_[1000:1300:6] - 1000) / rate, 40))
     np.testing.assert_allclose(
-        times[2500:], np.tile((np.r_[1000:1300:12] - 1000) / rate, 50))
+        times[2000:], np.tile((np.r_[1000:1300:12] - 1000) / rate, 50))
 
 
 @pytest.mark.parametrize('source', **pattern_sources)
@@ -232,15 +258,18 @@ def test_search_pulse_patterns(mock_spb_aux_run, source):
 
     for labelled in [True, False]:
         patterns = pulses.search_pulse_patterns(labelled=labelled)
-        assert len(patterns) == 2
-        assert patterns[0][0].value == by_id[10000:10049].value
-        np.testing.assert_equal(patterns[0][1], np.r_[1000:1300:6])
-        assert patterns[1][0].value == by_id[10050:10100].value
-        np.testing.assert_equal(patterns[1][1], np.r_[1000:1300:12])
+        assert len(patterns) == 3
+        assert patterns[0][0].value == by_id[10000:10009].value
+        assert len(patterns[0][1]) == 0
+        assert patterns[1][0].value == by_id[10010:10049].value
+        np.testing.assert_equal(patterns[1][1], np.r_[1000:1300:6])
+        assert patterns[2][0].value == by_id[10050:10100].value
+        np.testing.assert_equal(patterns[2][1], np.r_[1000:1300:12])
 
         if labelled:
-            np.testing.assert_equal(patterns[0][1].index, np.arange(50))
-            np.testing.assert_equal(patterns[1][1].index, np.arange(25))
+            assert patterns[0][1].index.empty
+            np.testing.assert_equal(patterns[1][1].index, np.arange(50))
+            np.testing.assert_equal(patterns[2][1].index, np.arange(25))
 
 
 @pytest.mark.parametrize('source', **pattern_sources)
@@ -249,7 +278,7 @@ def test_trains(mock_spb_aux_run, source):
     pulses = XrayPulses(run, source=source)
 
     for ref_tid, (tid_l, pids_l), (tid_ul, pids_ul) in zip(
-        run.train_ids, pulses.trains(), pulses.trains(labelled=False)
+        run.train_ids[10:], pulses.trains(), pulses.trains(labelled=False)
     ):
         assert ref_tid == tid_l == tid_ul
 
@@ -266,7 +295,7 @@ def test_trains(mock_spb_aux_run, source):
 @pytest.mark.parametrize('source', **pattern_sources)
 def test_optical_laser_basic(mock_spb_aux_run, source):
     run = mock_spb_aux_run
-    pulses = OpticalLaserPulses(run, source=source)
+    pulses = OpticalLaserPulses(run.select_trains(np.s_[10:]), source=source)
 
     assert pulses.ppl_seed == PPL_BITS.LP_SPB
     assert (pulses.get_pulse_counts() == 50).all()
@@ -391,10 +420,17 @@ def test_pump_probe_basic(mock_spb_aux_run, source):
     assert pulses.sase == 1
     assert pulses.ppl_seed == PPL_BITS.LP_SPB
 
+    with pytest.raises(ValueError):
+        # Cannot extrapolate due to missing pulses in the beginning.
+        pids = pulses.get_pulse_ids()
+
+    pulses = PumpProbePulses(run.select_trains(np.s_[10:]),
+                             source=source, pulse_offset=1)
+
     # Pulse IDs
     pids = pulses.get_pulse_ids()
     assert pids.index.names == ['trainId', 'pulseIndex', 'fel', 'ppl']
-    np.testing.assert_equal(pids[run.train_ids[0]], np.r_[1000:1306:6])
+    np.testing.assert_equal(pids[run.train_ids[10]], np.r_[1000:1306:6])
 
     fel = pids.index.get_level_values('fel')
     assert fel[:50].all()
@@ -414,7 +450,7 @@ def test_pump_probe_basic(mock_spb_aux_run, source):
     # Search patterns
     patterns = pulses.search_pulse_patterns()
     assert len(patterns) == 2
-    assert patterns[0][0].value == by_id[10000:10049].value
+    assert patterns[0][0].value == by_id[10010:10049].value
     np.testing.assert_equal(patterns[0][1], np.r_[1000:1306:6])
     assert patterns[1][0].value == by_id[10050:10100].value
     assert patterns[1][1].iloc[0] == 1000
@@ -426,7 +462,7 @@ def test_pump_probe_basic(mock_spb_aux_run, source):
 
 
 def test_pump_probe_defaults(mock_spb_aux_run):
-    run = mock_spb_aux_run.select('SPB*')
+    run = mock_spb_aux_run.select('SPB*').select_trains(np.s_[10:])
     np.testing.assert_equal(
         PumpProbePulses(run, pulse_offset=1).get_pulse_ids()[run.train_ids[0]],
         np.r_[1000:1306:6])

--- a/tests/test_components_pulses.py
+++ b/tests/test_components_pulses.py
@@ -354,6 +354,9 @@ def test_dld_pulses(capsys):
     assert pulse_ids.index.names == ['trainId', 'pulseIndex', 'fel', 'ppl']
     np.testing.assert_equal(pulse_ids, triggers['pulse'])
 
+    counts = pulses.get_pulse_counts()
+    np.testing.assert_equal(counts, np.array([10]))
+
     triggers_ = pulses.get_triggers()
     assert triggers_.index.names == ['trainId', 'pulseId', 'fel', 'ppl']
     np.testing.assert_equal(triggers_['start'],  triggers['start'])


### PR DESCRIPTION
The pulses components, in particular after some rework done in https://github.com/European-XFEL/EXtra/pull/40, did not properly handle trains that do not actually have pulses associated with them. This was mainly due to being overly reliant on constructing all kinds of data from the linear series of pulse IDs, which by nature will not contain empty trains in its index.

Most methods simply ignored trains without pulses even if they shouldn't (`.get_pulse_counts()`, `.get_pulse_mask()`, `.search_pulse_patterns()`) while others could simply break (`.select_trains()`). This MR fixes this behaviour across the boards and changes the tests to contain gaps in the pulse data, both in the sense of no data being recorded as well as recorded trains with no pulses. 