### PR TITLE
Add Documentation link for PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ classifiers = [
 
 [project.urls]
 Homepage = "https://github.com/European-XFEL/EXtra"
+Documentation = "https://extra.readthedocs.io/en/latest/"
 
 [project.optional-dependencies]
 test = [


### PR DESCRIPTION
If people find the [PyPI page](https://pypi.org/project/euxfel-EXtra/) for any reason, this link is likely more helpful to more people than going to Github.