### PR TITLE
Add some methods for statistics about pulse pattern

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,7 +5,10 @@
 
 # Changelog
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+Added:
+
+- `pulse_periods()`, `pulse_repetition_rates()` and `train_durations()` methods to obtain statistics about the pulses in all `PulsePattern`-based components
 
 <!-- !!! note -->
 <!--     All of the changes here are deployed to our current environment, even though -->

--- a/src/extra/components/pulses.py
+++ b/src/extra/components/pulses.py
@@ -185,7 +185,8 @@ class PulsePattern:
         return pulse_ids.copy() if copy else pulse_ids
 
     def get_pulse_ids(self, *args, **kwargs):
-        warn("Use pulse_ids() instead of get_pulse_ids()", DeprecationWarning, stacklevel=2)
+        warn("Use pulse_ids() instead of get_pulse_ids()",
+             DeprecationWarning, stacklevel=2)
         return self.pulse_ids(*args, **kwargs)
 
     def peek_pulse_ids(self, labelled=True):
@@ -259,7 +260,8 @@ class PulsePattern:
             return mask
 
     def get_pulse_mask(self, *args, **kwargs):
-        warn("Use pulse_mask() instead of get_pulse_mask()", DeprecationWarning, stacklevel=2)
+        warn("Use pulse_mask() instead of get_pulse_mask()",
+             DeprecationWarning, stacklevel=2)
         return self.pulse_mask(*args, **kwargs)
 
     def is_constant_pattern(self):
@@ -308,7 +310,8 @@ class PulsePattern:
         return counts if labelled else counts.to_numpy()
 
     def get_pulse_counts(self, *args, **kwargs):
-        warn("Use pulse_counts() instead of get_pulse_counts()", DeprecationWarning, stacklevel=2)
+        warn("Use pulse_counts() instead of get_pulse_counts()",
+             DeprecationWarning, stacklevel=2)
         return self.pulse_counts(*args, **kwargs)
 
     def build_pulse_index(self, pulse_dim='pulseId', include_extra_dims=True):
@@ -352,7 +355,8 @@ class PulsePattern:
             list(index_levels.values()), names=list(index_levels.keys()))
 
     def get_pulse_index(self, *args, **kwargs):
-        warn("Use build_pulse_index() instead of get_pulse_index()", DeprecationWarning, stacklevel=2)
+        warn("Use build_pulse_index() instead of get_pulse_index()",
+             DeprecationWarning, stacklevel=2)
         return self.build_pulse_index(*args, **kwargs)
 
     def search_pulse_patterns(self, labelled=True):
@@ -1139,5 +1143,6 @@ class DldPulses(PulsePattern):
             return triggers
 
     def get_triggers(self, *args, **kwargs):
-        warn("Use triggers() instead of get_triggers()", DeprecationWarning, stacklevel=2)
+        warn("Use triggers() instead of get_triggers()",
+             DeprecationWarning, stacklevel=2)
         return self.triggers(*args, **kwargs)

--- a/src/extra/components/pulses.py
+++ b/src/extra/components/pulses.py
@@ -338,7 +338,7 @@ class PulsePattern:
         the largest value encountered across other trains with more
         pulses.
 
-        The resulting series is casted to integer unless it contains
+        The resulting series is cast to integers unless it contains
         non-finite values as a result of fill values.
 
         Args:


### PR DESCRIPTION
Inspired by user feedback, this adds the three methods

* `PulsePattern.pulse_periods`
* `PulsePattern.pulse_repetition_rates`
* `PulsePattern.train_durations`

to the `PulsePattern` object, i.e. the parent of all pulse-related objects.

While these metrics are fundamentally easy to compute, there are a couple of corner cases and pitfalls that seem to warrant a robust implementation on our part - in particular handling no or a single pulse.

