### PR TITLE
Add PumpProbePulses to the component index

### DIFF
--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -13,4 +13,5 @@ Component index:
 - [Pulse patterns](pulse-patterns.md)
     - [XrayPulses][extra.components.XrayPulses]
     - [OpticalLaserPulses][extra.components.OpticalLaserPulses]
+    - [PumpProbePulses][extra.components.PumpProbePulses]
     - [DldPulses][extra.components.DldPulses]

--- a/docs/components/pulse-patterns.md
+++ b/docs/components/pulse-patterns.md
@@ -2,6 +2,6 @@
 
 ::: extra.components.OpticalLaserPulses
 
-::: extra.components.DldPulses
-
 ::: extra.components.PumpProbePulses
+
+::: extra.components.DldPulses


### PR DESCRIPTION
Also reordered the components in the documentation such that they vaguely go down by order of 'specificity'.

I noticed it was missing while reviewing #103.