### PR TITLE
Fix PumpProbePulses.pulse_mask() for empty or partially empty trains

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,7 +65,7 @@ def mock_spb_aux_directory():
     """Mock run directory with SPB auxiliary sources.
 
     Pulse pattern per train:
-        - 0:10, no pulses
+        - 0:5, no pulses
         - SA1
             - 10:50, 50 pulses at 1000:1300:6
             - 50:100, 25 pulses at 1000:1300:12
@@ -74,7 +74,7 @@ def mock_spb_aux_directory():
         - SA3
             - 10:100, 1 pulse at 200
         - LP_SPB
-            - 10:100, 50 pulses at 0:300:6
+            - 5:100, 50 pulses at 0:300:6
     """
 
     sources = [

--- a/tests/mockdata/timeserver.py
+++ b/tests/mockdata/timeserver.py
@@ -18,7 +18,7 @@ def _fill_bunch_pattern_table(table, num_rows, offset=10):
     table[offset:, 200] |= (DESTINATION_T4D | PHOTON_LINE_DEFLECTION)
 
     # LP_SPB
-    table[offset:, 0:300:6] |= PPL_BITS.LP_SPB
+    table[offset//2:, 0:300:6] |= PPL_BITS.LP_SPB
 
 
 class Timeserver(DeviceBase):


### PR DESCRIPTION
@bj-s reported an issue with `PumpProbePulses.pulse_mask()` in a run where all trains are pumped, but every 50th train has no FEL pulses.

The special implementation of `pulse_mask()` implicitly assumed every train to have at least one FEL and PPL pulse in its implementation. Additionally while fixing this, I noticed it was not included in the fixes in https://github.com/European-XFEL/EXtra/pull/100 regarding handling of trains without pulses.

Extended the tests to cover what previously failed.