### PR TITLE
Store & access all CCV metadata from CalCat

### DIFF
--- a/src/extra/calibration.py
+++ b/src/extra/calibration.py
@@ -256,6 +256,7 @@ class SingleConstant:
     dataset: str
     ccv_id: Optional[int]
     pdu_name: Optional[str]
+    _calcat_metadata: Optional[dict] = None
 
     @classmethod
     def from_response(cls, ccv: dict) -> "SingleConstant":
@@ -264,6 +265,7 @@ class SingleConstant:
             dataset=ccv["data_set_name"],
             ccv_id=ccv["id"],
             pdu_name=ccv["physical_detector_unit"]["physical_name"],
+            _calcat_metadata=ccv,
         )
 
     def dataset_obj(self, caldb_root=None) -> h5py.Dataset:
@@ -277,6 +279,17 @@ class SingleConstant:
 
     def ndarray(self, caldb_root=None):
         return self.dataset_obj(caldb_root)[:]
+
+    def calcat_metadata(self, client=None):
+        if self._calcat_metadata is None:
+            if self.ccv_id is None:
+                raise Exception("Unable to retrieve metadata without ccv_id")
+
+            client = client or get_client()
+            self._calcat_metadata = client.get(
+                f"calibration_constant_versions/{self.ccv_id}"
+            )
+        return self._calcat_metadata
 
 
 def prepare_selection(

--- a/src/extra/calibration.py
+++ b/src/extra/calibration.py
@@ -1,7 +1,7 @@
 import json
 import re
 from collections.abc import Mapping
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from datetime import date, datetime, time, timezone
 from functools import lru_cache
 from pathlib import Path
@@ -256,7 +256,8 @@ class SingleConstant:
     dataset: str
     ccv_id: Optional[int]
     pdu_name: Optional[str]
-    _calcat_metadata: Optional[dict] = None
+    _metadata: dict = field(default_factory=dict)
+    _have_calcat_metadata: bool = False
 
     @classmethod
     def from_response(cls, ccv: dict) -> "SingleConstant":
@@ -265,7 +266,8 @@ class SingleConstant:
             dataset=ccv["data_set_name"],
             ccv_id=ccv["id"],
             pdu_name=ccv["physical_detector_unit"]["physical_name"],
-            _calcat_metadata=ccv,
+            _metadata=ccv,
+            _have_calcat_metadata=True,
         )
 
     def dataset_obj(self, caldb_root=None) -> h5py.Dataset:
@@ -280,16 +282,36 @@ class SingleConstant:
     def ndarray(self, caldb_root=None):
         return self.dataset_obj(caldb_root)[:]
 
-    def calcat_metadata(self, client=None):
-        if self._calcat_metadata is None:
-            if self.ccv_id is None:
-                raise Exception("Unable to retrieve metadata without ccv_id")
+    def _load_calcat_metadata(self, client=None):
+        client = client or get_client()
+        calcat_meta = client.get(f"calibration_constant_versions/{self.ccv_id}")
+        # Any metadata we already have takes precedence over CalCat, so
+        # this can't change a value that was previously returned.
+        self._metadata = calcat_meta | self._metadata
+        self._have_calcat_metadata = True
 
-            client = client or get_client()
-            self._calcat_metadata = client.get(
-                f"calibration_constant_versions/{self.ccv_id}"
-            )
-        return self._calcat_metadata
+
+    def metadata(self, key, client=None):
+        """Get a specific metadata field, e.g. 'begin_validity_at'
+
+        This may make a request to CalCat if the value is not already known.
+        """
+        if key not in self._metadata and not self._have_calcat_metadata:
+            if self.ccv_id is None:
+                raise KeyError(f"{key!r} (no CCV ID to request data from CalCat")
+            self._load_calcat_metadata(client)
+
+        return self._metadata[key]
+
+    def metadata_dict(self, client=None):
+        """Get a dict of available metadata
+
+        If this constant didn't come from CalCat but we have a CalCat CCV ID,
+        this will fetch metadata from CalCat.
+        """
+        if (not self._have_calcat_metadata) and (self.ccv_id is not None):
+            self._load_calcat_metadata(client)
+        return self._metadata.copy()
 
 
 def prepare_selection(

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -56,7 +56,8 @@ def test_AGIPD_CalibrationData_metadata():
     assert set(agipd_cd["Offset"].constants) == {f"AGIPD{m:02}" for m in range(16)}
     assert isinstance(agipd_cd["Offset", "AGIPD00"], SingleConstant)
     assert agipd_cd["Offset", "Q1M2"] == agipd_cd["Offset", "AGIPD01"]
-
+    bva = agipd_cd["Offset", "AGIPD00"].calcat_metadata()["begin_validity_at"]
+    assert bva == "2022-09-02T07:42:33.000+02:00"
 
 @pytest.mark.vcr
 def test_AGIPD_merge():

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -56,8 +56,11 @@ def test_AGIPD_CalibrationData_metadata():
     assert set(agipd_cd["Offset"].constants) == {f"AGIPD{m:02}" for m in range(16)}
     assert isinstance(agipd_cd["Offset", "AGIPD00"], SingleConstant)
     assert agipd_cd["Offset", "Q1M2"] == agipd_cd["Offset", "AGIPD01"]
-    bva = agipd_cd["Offset", "AGIPD00"].calcat_metadata()["begin_validity_at"]
+
+    bva = agipd_cd["Offset", "AGIPD00"].metadata("begin_validity_at")
     assert bva == "2022-09-02T07:42:33.000+02:00"
+    metadata = agipd_cd["Offset", "AGIPD00"].metadata_dict()
+    assert metadata["begin_validity_at"] == bva
 
 @pytest.mark.vcr
 def test_AGIPD_merge():


### PR DESCRIPTION
I stripped almost all the metadata attributes from `SingleConstant`, because I think the API should be usable even without talking to CalCat. But naturally there are times when we want that metadata, e.g. to show the timestamp (`begin_validity_at`) in correction reports.

This is designed to handle 3 scenarios:

1. We found the constants from CalCat - store all the CCV metadata from the response, make it available 'free'
2. We got constants another way which includes CCV IDs, e.g. metadata from a correction - you can use constants without talking to CalCat, but if you want the metadata, it will need 1 query per SingleConstant object.
3. We got constants without CCV IDs, e.g. testing constants that have not yet been injected to CalCat - no metadata available, but you can still organise them & load data through this API.