### PR TITLE
Make CI check that the changelog was modified

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,25 @@
+# Check that the changelog has been updated.
+# See: https://github.com/marketplace/actions/changelog-enforcer
+
+name: "PR workflow"
+on:
+  pull_request:
+    # The specific activity types are listed here to include "labeled" and "unlabeled"
+    # (which are not included by default for the "pull_request" trigger).
+    # This is needed to allow skipping enforcement of the changelog in PRs with specific labels,
+    # as defined in the (optional) "skipLabels" property.
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  # Enforces the update of a changelog file on every pull request
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Enforce changelog update
+      uses: dangoslen/changelog-enforcer@v3
+      with:
+        changeLogPath: docs/changelog.md
+        skipLabels: "skip-changelog, dependencies, documentation"


### PR DESCRIPTION
It can be overridden with the `skip-changelog` label.