### PR TITLE
Add MachinePulses implementation for arbitrary pulse pattern information

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,6 +18,8 @@
 
 Added:
 
+- [MachinePulses][extra.components.MachinePulses] to investigate pulse pattern
+  data beyond only X-rays and optical lasers (!138).
 - Implemented [Scan.bin_by_steps()][extra.components.Scan.bin_by_steps] and
   [Scan.plot_bin_by_steps()][extra.components.Scan.plot_bin_by_steps] to help
   with averaging data over scan steps (!124).

--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -14,4 +14,5 @@ Component index:
     - [XrayPulses][extra.components.XrayPulses]
     - [OpticalLaserPulses][extra.components.OpticalLaserPulses]
     - [PumpProbePulses][extra.components.PumpProbePulses]
+    - [MachinePulses][extra.components.MachinePulses]
     - [DldPulses][extra.components.DldPulses]

--- a/docs/components/pulse-patterns.md
+++ b/docs/components/pulse-patterns.md
@@ -4,4 +4,6 @@
 
 ::: extra.components.PumpProbePulses
 
+::: extra.components.MachinePulses
+
 ::: extra.components.DldPulses

--- a/src/extra/components/__init__.py
+++ b/src/extra/components/__init__.py
@@ -1,5 +1,6 @@
 
 from .scantool import Scantool  # noqa
-from .pulses import XrayPulses, OpticalLaserPulses, PumpProbePulses, DldPulses  # noqa
+from .pulses import XrayPulses, OpticalLaserPulses, MachinePulses, \
+    PumpProbePulses, DldPulses  # noqa
 from .scan import Scan  # noqa
 from .xgm import XGM  # noqa

--- a/src/extra/components/pulses.py
+++ b/src/extra/components/pulses.py
@@ -607,6 +607,17 @@ class TimeserverPulses(PulsePattern):
 
         super().__init__(sd, kd)
 
+    def __repr__(self, location=None):
+        if self._with_timeserver:
+            source_type = 'timeserver'
+        else:
+            source_type = 'ppdecoder'
+
+        loc_str = ' ' + location if location is not None else ''
+
+        return "<{}{} using {}={}>".format(
+            type(self).__name__, loc_str, source_type, self._source.source)
+
     @classmethod
     def _find_pulsepattern_source(cls, data):
         """Try to find a pulse pattern source."""
@@ -817,13 +828,7 @@ class XrayPulses(TimeserverPulses):
         self._sase = sase
 
     def __repr__(self):
-        if self._with_timeserver:
-            source_type = 'timeserver'
-        else:
-            source_type = 'ppdecoder'
-
-        return "<{} for SA{} using {}={}>".format(
-            type(self).__name__, self._sase, source_type, self._source.source)
+        return super().__repr__(f'for SA{self._sase}')
 
     def _mask_table(self, table):
         return is_sase(table, sase=self._sase)
@@ -909,14 +914,7 @@ class OpticalLaserPulses(TimeserverPulses):
         self._ppl_seed = ppl_seed
 
     def __repr__(self):
-        if self._with_timeserver:
-            source_type = 'timeserver'
-        else:
-            source_type = 'ppdecoder'
-
-        return "<{} for {} using {}={}>".format(
-                type(self).__name__, self._ppl_seed.name, source_type,
-                self._source.source)
+        return super().__repr__(self._ppl_seed.name)
 
     @classmethod
     def _identify_ppl_seed(cls, data):


### PR DESCRIPTION
The final member in the originally planned `PulsePattern` family: `MachinePulses`

It is essentially a more general version of `XrayPulses` and `OpticalLaserPulses`, allowing to access arbittary bit masks in the pulse pattern table. By default, it is configured to look at all electron bunches (_pulses_) as means to investigate machine operation. This is also the only mode supported when used with pulse pattern decoder data.

When used with timeserver data, any combination of bits can be accessed with both all (`mode='and'`) or any (`mode='or'`, default) bits set. 

There a couple of small changes to parent classes to accomodate the previously unplanned support of ppdecoder at all.