### PR TITLE
Add job to publish packages on PyPI when a tag passes tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,7 @@ name: Tests
 on:
   push:
     branches: [ master ]
+    tags: [ '*' ]
   pull_request:
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,3 +36,27 @@ jobs:
         python3 -m pytest .
       env:
         CALCAT_OAUTH_CREDS: ${{ secrets.CALCAT_OAUTH_CREDS }}
+
+  publish:
+    runs-on: ubuntu-latest
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    needs: tests
+    permissions:
+      id-token: write  # OIDC for uploading to PyPI
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Build packages
+        run: |
+          python3 -m pip install build
+          python3 -m build
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
@daviddoji was using an older version, because the 2024.1 tag was not published to PyPI. This automates that step, so packages will be uploaded automatically for a tag, so long as it passes tests.

@philsmt @tmichela This also needs some config on PyPI to allow it to upload ('trusted publisher'). I don't seem to have enough access to set that up.