### PR TITLE
Calibration: Add source names for detector modules (using source_name_pattern)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,6 +18,7 @@
 Added:
 
 - A helper function named [fit_gaussian()][extra.utils.fit_gaussian] (!131).
+- Support for module source names in `extra.calibration` (!146).
 
 ## [2024.1.1]
 

--- a/src/extra/calibration.py
+++ b/src/extra/calibration.py
@@ -400,7 +400,12 @@ class MultiModuleConstant(Mapping):
             candidate_kdas.add(key)
 
         for m in self.module_details:
-            names = (m["module_number"], m["virtual_device_name"], m["physical_name"])
+            names = (
+                m["module_number"],
+                m["virtual_device_name"],
+                m["physical_name"],
+                m.get('source_name', None),
+            )
             if key in names and m["karabo_da"] in self.constants:
                 candidate_kdas.add(m["karabo_da"])
 

--- a/tests/cassettes/test_calibration/test_AGIPD_funky_numbering.yaml
+++ b/tests/cassettes/test_calibration/test_AGIPD_funky_numbering.yaml
@@ -1,0 +1,984 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json; version=2
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - EXtra/2024.1.58+56cd5fc
+      content-type:
+      - application/json
+    method: GET
+    uri: http://exflcalproxy.desy.de:8080/api/me
+  response:
+    body:
+      string: '{"id":-9,"email":"admin@example.com","created_at":"2015-03-12T17:02:47.000+01:00","updated_at":"2023-07-12T11:10:34.000+02:00","provider":"local","uid":null,"name":"Admin
+        User","first_name":"Admin","last_name":"User","nickname":null,"contact_email":"admin@example.com","ldap_synced_at":null,"flg_ldap_account_valid":false,"flg_service_account":true}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '349'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 22 Mar 2024 17:41:45 GMT
+      Etag:
+      - W/"b842139470fd3dd760b95ece26a10a4b"
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=16070400; includeSubDomains
+      Vary:
+      - Origin
+      Via:
+      - HTTP/1.1 xfel_oauth_proxy
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R)
+      X-Request-Id:
+      - 8dbf6341-1d33-4915-8392-339ba7f90153
+      X-Runtime:
+      - '0.027228'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json; version=2
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - EXtra/2024.1.58+56cd5fc
+      content-type:
+      - application/json
+    method: GET
+    uri: http://exflcalproxy.desy.de:8080/api/detectors?identifier=HED_DET_AGIPD65K1
+  response:
+    body:
+      string: '[{"id":50,"name":"HED_DET_AGIPD65K1","identifier":"HED_DET_AGIPD65K1","karabo_name":"HED_DET_AGIPD65K1","karabo_id_control":"HED_DET_AGIPD65K1","source_name_pattern":"HED_DET_AGIPD65K1/DET/{modno+8}CH0:xtdf","number_of_modules":1,"first_module_index":0,"flg_available":true,"description":null,"detectors_instruments":[{"instrument_id":5,"detector_id":50}]}]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '357'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 22 Mar 2024 17:41:45 GMT
+      Etag:
+      - W/"8300d78c77b926ac723e5061c8f797f8"
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=16070400; includeSubDomains
+      Vary:
+      - Origin
+      Via:
+      - HTTP/1.1 xfel_oauth_proxy
+      X-Content-Type-Options:
+      - nosniff
+      X-Count-Per-Page:
+      - '100'
+      X-Current-Page:
+      - '1'
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R)
+      X-Request-Id:
+      - 2385c305-c5d5-41ae-9615-f50abb938891
+      X-Runtime:
+      - '0.025214'
+      X-Total-Count:
+      - '1'
+      X-Total-Pages:
+      - '1'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json; version=2
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - EXtra/2024.1.58+56cd5fc
+      content-type:
+      - application/json
+    method: GET
+    uri: http://exflcalproxy.desy.de:8080/api/physical_detector_units/get_all_by_detector?detector_id=50&pdu_snapshot_at=2024-03-22T17%3A19%3A15.965988%2B00%3A00
+  response:
+    body:
+      string: '[{"id":237,"physical_name":"AGIPD_SIV1_AGIPDV12_MS01","karabo_da":"AGIPD08","virtual_device_name":"Q1M1","uuid":102153100001,"float_uuid":5.04703373267e-313,"detector_type_id":2,"detector_id":50,"module_number":0,"flg_available":true,"description":"The
+        module is from SPARTA system from X-Spectrum, this is why we use MSXX instead
+        of MXXX as for other AGIPDS detectors.","detector":{"id":50,"name":"HED_DET_AGIPD65K1","identifier":"HED_DET_AGIPD65K1","karabo_name":"HED_DET_AGIPD65K1","karabo_id_control":"HED_DET_AGIPD65K1","source_name_pattern":"HED_DET_AGIPD65K1/DET/{modno+8}CH0:xtdf","number_of_modules":1,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":null}}]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '761'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 22 Mar 2024 17:41:45 GMT
+      Etag:
+      - W/"8bff8b05354e0d5787ceaf49fd97d855"
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=16070400; includeSubDomains
+      Vary:
+      - Origin
+      Via:
+      - HTTP/1.1 xfel_oauth_proxy
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R)
+      X-Request-Id:
+      - d1d97319-4861-4c11-a1e7-1b5c3fc891de
+      X-Runtime:
+      - '0.368337'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json; version=2
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - EXtra/2024.1.58+56cd5fc
+      content-type:
+      - application/json
+    method: GET
+    uri: http://exflcalproxy.desy.de:8080/api/calibrations?name=Offset
+  response:
+    body:
+      string: '[{"id":1,"name":"Offset","unit_id":1,"max_value":null,"min_value":null,"allowed_deviation":null,"description":""}]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '114'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 22 Mar 2024 17:41:45 GMT
+      Etag:
+      - W/"41e8088cc44ad976e577e40482d74dfb"
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=16070400; includeSubDomains
+      Vary:
+      - Origin
+      Via:
+      - HTTP/1.1 xfel_oauth_proxy
+      X-Content-Type-Options:
+      - nosniff
+      X-Count-Per-Page:
+      - '100'
+      X-Current-Page:
+      - '1'
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R)
+      X-Request-Id:
+      - 9357eb65-5658-4a2f-86c2-ea363e72f0ff
+      X-Runtime:
+      - '0.025650'
+      X-Total-Count:
+      - '1'
+      X-Total-Pages:
+      - '1'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json; version=2
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - EXtra/2024.1.58+56cd5fc
+      content-type:
+      - application/json
+    method: GET
+    uri: http://exflcalproxy.desy.de:8080/api/calibrations?name=Noise
+  response:
+    body:
+      string: '[{"id":2,"name":"Noise","unit_id":1,"max_value":null,"min_value":null,"allowed_deviation":null,"description":"In
+        terms of standard deviation"}]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '143'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 22 Mar 2024 17:41:46 GMT
+      Etag:
+      - W/"f1826d5b0b4d30aa8e2a90eb504451d1"
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=16070400; includeSubDomains
+      Vary:
+      - Origin
+      Via:
+      - HTTP/1.1 xfel_oauth_proxy
+      X-Content-Type-Options:
+      - nosniff
+      X-Count-Per-Page:
+      - '100'
+      X-Current-Page:
+      - '1'
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R)
+      X-Request-Id:
+      - c26fe1c0-8414-49d9-aa62-e67b70ed1f6d
+      X-Runtime:
+      - '0.027212'
+      X-Total-Count:
+      - '1'
+      X-Total-Pages:
+      - '1'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json; version=2
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - EXtra/2024.1.58+56cd5fc
+      content-type:
+      - application/json
+    method: GET
+    uri: http://exflcalproxy.desy.de:8080/api/calibrations?name=ThresholdsDark
+  response:
+    body:
+      string: '[{"id":11,"name":"ThresholdsDark","unit_id":1,"max_value":null,"min_value":null,"allowed_deviation":null,"description":""}]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '123'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 22 Mar 2024 17:41:46 GMT
+      Etag:
+      - W/"f43889846a525288071dc7af3cbabc47"
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=16070400; includeSubDomains
+      Vary:
+      - Origin
+      Via:
+      - HTTP/1.1 xfel_oauth_proxy
+      X-Content-Type-Options:
+      - nosniff
+      X-Count-Per-Page:
+      - '100'
+      X-Current-Page:
+      - '1'
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R)
+      X-Request-Id:
+      - 0fef62ca-c120-4a51-8466-ad27cd3ed3b5
+      X-Runtime:
+      - '0.024566'
+      X-Total-Count:
+      - '1'
+      X-Total-Pages:
+      - '1'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json; version=2
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - EXtra/2024.1.58+56cd5fc
+      content-type:
+      - application/json
+    method: GET
+    uri: http://exflcalproxy.desy.de:8080/api/calibrations?name=BadPixelsDark
+  response:
+    body:
+      string: '[{"id":14,"name":"BadPixelsDark","unit_id":1,"max_value":null,"min_value":null,"allowed_deviation":null,"description":""}]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '122'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 22 Mar 2024 17:41:46 GMT
+      Etag:
+      - W/"0e4753c0e3b62586fa4dd1eadedc8ec2"
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=16070400; includeSubDomains
+      Vary:
+      - Origin
+      Via:
+      - HTTP/1.1 xfel_oauth_proxy
+      X-Content-Type-Options:
+      - nosniff
+      X-Count-Per-Page:
+      - '100'
+      X-Current-Page:
+      - '1'
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R)
+      X-Request-Id:
+      - dd3abefc-7c74-4945-9d7b-2b132915e612
+      X-Runtime:
+      - '0.028453'
+      X-Total-Count:
+      - '1'
+      X-Total-Pages:
+      - '1'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"parameters_conditions_attributes": [{"parameter_name": "Sensor Bias Voltage",
+      "value": "200.0"}, {"parameter_name": "Pixels X", "value": "512"}, {"parameter_name":
+      "Pixels Y", "value": "128"}, {"parameter_name": "Memory cells", "value": "352"},
+      {"parameter_name": "Acquisition rate", "value": "1.1"}, {"parameter_name": "Gain
+      setting", "value": "0"}]}'
+    headers:
+      Accept:
+      - application/json; version=2
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '353'
+      User-Agent:
+      - EXtra/2024.1.58+56cd5fc
+      content-type:
+      - application/json
+    method: GET
+    uri: http://exflcalproxy.desy.de:8080/api/calibration_constant_versions/get_by_detector_conditions?detector_identifier=HED_DET_AGIPD65K1&calibration_id=%5B1%2C+2%2C+11%2C+14%5D&karabo_da=&event_at=2024-03-22T17%3A19%3A15.965988%2B00%3A00&pdu_snapshot_at=2024-03-22T17%3A19%3A15.965988%2B00%3A00
+  response:
+    body:
+      string: '[{"id":195905,"name":"20240223_140953_sIdx=0","file_name":"cal.1708697392.791521.h5","path_to_file":"xfel/cal/agipd-type/agipd_siv1_agipdv12_ms01/","data_set_name":"/AGIPD_SIV1_AGIPDV12_MS01/Offset/0","flg_deployed":true,"flg_good_quality":true,"begin_validity_at":"2024-02-23T15:00:34.000+01:00","end_validity_at":null,"begin_at":"2024-02-23T15:00:34.000+01:00","start_idx":0,"end_idx":0,"raw_data_location":"proposal:900438
+        runs:56 55 54","report_id":4673,"description":"","created_at":"2024-02-23T15:09:54.000+01:00","calibration_constant":{"id":27264,"name":"AGIPD-Type_Offset_AGIPD
+        DefoY76o2AcUih2Fd9+K2obaQ==\n","detector_type_id":2,"calibration_id":1,"condition_id":8714,"flg_auto_approve":true,"flg_available":true,"description":"Per-pixel
+        (per-memory cell) offset","created_at":"2024-02-23T15:09:53.000+01:00","updated_at":"2024-02-23T15:09:53.000+01:00"},"physical_detector_unit":{"id":237,"physical_name":"AGIPD_SIV1_AGIPDV12_MS01","detector_type_id":2,"flg_available":true,"description":"The
+        module is from SPARTA system from X-Spectrum, this is why we use MSXX instead
+        of MXXX as for other AGIPDS detectors.","created_at":"2024-02-20T13:20:25.000+01:00","updated_at":"2024-02-23T15:07:49.000+01:00","karabo_da":"AGIPD08","detector_id":50,"virtual_device_name":"Q1M1","uuid":102153100001,"float_uuid":5.04703373267e-313,"module_number":0,"karabo_da_at_ccv_begin_at":"AGIPD08","detector_id_at_ccv_begin_at":50,"virtual_device_name_at_ccv_begin_at":"Q1M1","module_number_at_ccv_begin_at":null}},{"id":195906,"name":"20240223_140957_sIdx=0","file_name":"cal.1708697396.4114847.h5","path_to_file":"xfel/cal/agipd-type/agipd_siv1_agipdv12_ms01/","data_set_name":"/AGIPD_SIV1_AGIPDV12_MS01/Noise/0","flg_deployed":true,"flg_good_quality":true,"begin_validity_at":"2024-02-23T15:00:34.000+01:00","end_validity_at":null,"begin_at":"2024-02-23T15:00:34.000+01:00","start_idx":0,"end_idx":0,"raw_data_location":"proposal:900438
+        runs:56 55 54","report_id":4673,"description":"","created_at":"2024-02-23T15:09:57.000+01:00","calibration_constant":{"id":27265,"name":"AGIPD-Type_Noise_AGIPD
+        DefoY76o2AcUih2Fd9+K2obaQ==\n","detector_type_id":2,"calibration_id":2,"condition_id":8714,"flg_auto_approve":true,"flg_available":true,"description":"Per-pixel
+        (per-memory cell) noise","created_at":"2024-02-23T15:09:57.000+01:00","updated_at":"2024-02-23T15:09:57.000+01:00"},"physical_detector_unit":{"id":237,"physical_name":"AGIPD_SIV1_AGIPDV12_MS01","detector_type_id":2,"flg_available":true,"description":"The
+        module is from SPARTA system from X-Spectrum, this is why we use MSXX instead
+        of MXXX as for other AGIPDS detectors.","created_at":"2024-02-20T13:20:25.000+01:00","updated_at":"2024-02-23T15:07:49.000+01:00","karabo_da":"AGIPD08","detector_id":50,"virtual_device_name":"Q1M1","uuid":102153100001,"float_uuid":5.04703373267e-313,"module_number":0,"karabo_da_at_ccv_begin_at":"AGIPD08","detector_id_at_ccv_begin_at":50,"virtual_device_name_at_ccv_begin_at":"Q1M1","module_number_at_ccv_begin_at":null}},{"id":195908,"name":"20240223_141005_sIdx=0","file_name":"cal.1708697404.4392803.h5","path_to_file":"xfel/cal/agipd-type/agipd_siv1_agipdv12_ms01/","data_set_name":"/AGIPD_SIV1_AGIPDV12_MS01/ThresholdsDark/0","flg_deployed":true,"flg_good_quality":true,"begin_validity_at":"2024-02-23T15:00:34.000+01:00","end_validity_at":null,"begin_at":"2024-02-23T15:00:34.000+01:00","start_idx":0,"end_idx":0,"raw_data_location":"proposal:900438
+        runs:56 55 54","report_id":4673,"description":"","created_at":"2024-02-23T15:10:05.000+01:00","calibration_constant":{"id":27267,"name":"AGIPD-Type_ThresholdsDark_AGIPD
+        DefoY76o2AcUih2Fd9+K2obaQ==\n","detector_type_id":2,"calibration_id":11,"condition_id":8714,"flg_auto_approve":true,"flg_available":true,"description":"Per-pixel
+        (per-memory cell) thresholds from dark runs","created_at":"2024-02-23T15:10:05.000+01:00","updated_at":"2024-02-23T15:10:05.000+01:00"},"physical_detector_unit":{"id":237,"physical_name":"AGIPD_SIV1_AGIPDV12_MS01","detector_type_id":2,"flg_available":true,"description":"The
+        module is from SPARTA system from X-Spectrum, this is why we use MSXX instead
+        of MXXX as for other AGIPDS detectors.","created_at":"2024-02-20T13:20:25.000+01:00","updated_at":"2024-02-23T15:07:49.000+01:00","karabo_da":"AGIPD08","detector_id":50,"virtual_device_name":"Q1M1","uuid":102153100001,"float_uuid":5.04703373267e-313,"module_number":0,"karabo_da_at_ccv_begin_at":"AGIPD08","detector_id_at_ccv_begin_at":50,"virtual_device_name_at_ccv_begin_at":"Q1M1","module_number_at_ccv_begin_at":null}},{"id":195907,"name":"20240223_141000_sIdx=0","file_name":"cal.1708697399.0664325.h5","path_to_file":"xfel/cal/agipd-type/agipd_siv1_agipdv12_ms01/","data_set_name":"/AGIPD_SIV1_AGIPDV12_MS01/BadPixelsDark/0","flg_deployed":true,"flg_good_quality":true,"begin_validity_at":"2024-02-23T15:00:34.000+01:00","end_validity_at":null,"begin_at":"2024-02-23T15:00:34.000+01:00","start_idx":0,"end_idx":0,"raw_data_location":"proposal:900438
+        runs:56 55 54","report_id":4673,"description":"","created_at":"2024-02-23T15:10:00.000+01:00","calibration_constant":{"id":27266,"name":"AGIPD-Type_BadPixelsDark_AGIPD
+        DefoY76o2AcUih2Fd9+K2obaQ==\n","detector_type_id":2,"calibration_id":14,"condition_id":8714,"flg_auto_approve":true,"flg_available":true,"description":"Per-pixel
+        (per-memory cell) bad pixels from dark runs","created_at":"2024-02-23T15:10:00.000+01:00","updated_at":"2024-02-23T15:10:00.000+01:00"},"physical_detector_unit":{"id":237,"physical_name":"AGIPD_SIV1_AGIPDV12_MS01","detector_type_id":2,"flg_available":true,"description":"The
+        module is from SPARTA system from X-Spectrum, this is why we use MSXX instead
+        of MXXX as for other AGIPDS detectors.","created_at":"2024-02-20T13:20:25.000+01:00","updated_at":"2024-02-23T15:07:49.000+01:00","karabo_da":"AGIPD08","detector_id":50,"virtual_device_name":"Q1M1","uuid":102153100001,"float_uuid":5.04703373267e-313,"module_number":0,"karabo_da_at_ccv_begin_at":"AGIPD08","detector_id_at_ccv_begin_at":50,"virtual_device_name_at_ccv_begin_at":"Q1M1","module_number_at_ccv_begin_at":null}}]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '6087'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 22 Mar 2024 17:41:46 GMT
+      Etag:
+      - W/"89c898fae9e24270f3354bb80995dd05"
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=16070400; includeSubDomains
+      Vary:
+      - Origin
+      Via:
+      - HTTP/1.1 xfel_oauth_proxy
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R)
+      X-Request-Id:
+      - a9600ffb-e0f0-4688-8933-2be54f36ea22
+      X-Runtime:
+      - '0.541094'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json; version=2
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - EXtra/2024.1.58+56cd5fc
+      content-type:
+      - application/json
+    method: GET
+    uri: http://exflcalproxy.desy.de:8080/api/calibrations?name=BadPixelsPC
+  response:
+    body:
+      string: '[{"id":15,"name":"BadPixelsPC","unit_id":1,"max_value":null,"min_value":null,"allowed_deviation":null,"description":""}]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '120'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 22 Mar 2024 17:41:46 GMT
+      Etag:
+      - W/"59c04585d60766363edf6d7d8b2b1de5"
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=16070400; includeSubDomains
+      Vary:
+      - Origin
+      Via:
+      - HTTP/1.1 xfel_oauth_proxy
+      X-Content-Type-Options:
+      - nosniff
+      X-Count-Per-Page:
+      - '100'
+      X-Current-Page:
+      - '1'
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R)
+      X-Request-Id:
+      - 2ddef0d5-8d8f-44aa-b34b-b29b63696936
+      X-Runtime:
+      - '0.027274'
+      X-Total-Count:
+      - '1'
+      X-Total-Pages:
+      - '1'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json; version=2
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - EXtra/2024.1.58+56cd5fc
+      content-type:
+      - application/json
+    method: GET
+    uri: http://exflcalproxy.desy.de:8080/api/calibrations?name=SlopesPC
+  response:
+    body:
+      string: '[{"id":17,"name":"SlopesPC","unit_id":19,"max_value":null,"min_value":null,"allowed_deviation":null,"description":""}]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '118'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 22 Mar 2024 17:41:46 GMT
+      Etag:
+      - W/"2cd54fe20b3b330444a62a1f2c8e42f5"
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=16070400; includeSubDomains
+      Vary:
+      - Origin
+      Via:
+      - HTTP/1.1 xfel_oauth_proxy
+      X-Content-Type-Options:
+      - nosniff
+      X-Count-Per-Page:
+      - '100'
+      X-Current-Page:
+      - '1'
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R)
+      X-Request-Id:
+      - e8d92638-f38d-444d-a387-f647fc881bd0
+      X-Runtime:
+      - '0.026825'
+      X-Total-Count:
+      - '1'
+      X-Total-Pages:
+      - '1'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"parameters_conditions_attributes": [{"parameter_name": "Sensor Bias Voltage",
+      "value": "200.0"}, {"parameter_name": "Pixels X", "value": "512"}, {"parameter_name":
+      "Pixels Y", "value": "128"}, {"parameter_name": "Memory cells", "value": "352"},
+      {"parameter_name": "Acquisition rate", "value": "1.1"}, {"parameter_name": "Gain
+      setting", "value": "0"}]}'
+    headers:
+      Accept:
+      - application/json; version=2
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '353'
+      User-Agent:
+      - EXtra/2024.1.58+56cd5fc
+      content-type:
+      - application/json
+    method: GET
+    uri: http://exflcalproxy.desy.de:8080/api/calibration_constant_versions/get_by_detector_conditions?detector_identifier=HED_DET_AGIPD65K1&calibration_id=%5B15%2C+17%5D&karabo_da=&event_at=2024-03-22T17%3A19%3A15.965988%2B00%3A00&pdu_snapshot_at=2024-03-22T17%3A19%3A15.965988%2B00%3A00
+  response:
+    body:
+      string: '[]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 22 Mar 2024 17:41:46 GMT
+      Etag:
+      - W/"4f53cda18c2baa0c0354bb5f9a3ecbe5"
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=16070400; includeSubDomains
+      Vary:
+      - Origin
+      Via:
+      - HTTP/1.1 xfel_oauth_proxy
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R)
+      X-Request-Id:
+      - 8d116941-5118-4cfa-8e75-0564c95e099c
+      X-Runtime:
+      - '0.491049'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json; version=2
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - EXtra/2024.1.58+56cd5fc
+      content-type:
+      - application/json
+    method: GET
+    uri: http://exflcalproxy.desy.de:8080/api/calibrations?name=BadPixelsFF
+  response:
+    body:
+      string: '[{"id":20,"name":"BadPixelsFF","unit_id":19,"max_value":null,"min_value":null,"allowed_deviation":null,"description":""}]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '121'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 22 Mar 2024 17:41:47 GMT
+      Etag:
+      - W/"8d637e112231afb0794d657d8bf9dd6c"
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=16070400; includeSubDomains
+      Vary:
+      - Origin
+      Via:
+      - HTTP/1.1 xfel_oauth_proxy
+      X-Content-Type-Options:
+      - nosniff
+      X-Count-Per-Page:
+      - '100'
+      X-Current-Page:
+      - '1'
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R)
+      X-Request-Id:
+      - e02aff3f-539f-4882-a1e7-e965e4a94bb4
+      X-Runtime:
+      - '0.028397'
+      X-Total-Count:
+      - '1'
+      X-Total-Pages:
+      - '1'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json; version=2
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - EXtra/2024.1.58+56cd5fc
+      content-type:
+      - application/json
+    method: GET
+    uri: http://exflcalproxy.desy.de:8080/api/calibrations?name=SlopesFF
+  response:
+    body:
+      string: '[{"id":19,"name":"SlopesFF","unit_id":19,"max_value":null,"min_value":null,"allowed_deviation":null,"description":""}]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '118'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 22 Mar 2024 17:41:47 GMT
+      Etag:
+      - W/"50ec44b55aad814d2d09049e151bfba8"
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=16070400; includeSubDomains
+      Vary:
+      - Origin
+      Via:
+      - HTTP/1.1 xfel_oauth_proxy
+      X-Content-Type-Options:
+      - nosniff
+      X-Count-Per-Page:
+      - '100'
+      X-Current-Page:
+      - '1'
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R)
+      X-Request-Id:
+      - 4f7c12ad-aafb-4e00-9cd0-f0a6499bb7d5
+      X-Runtime:
+      - '0.029030'
+      X-Total-Count:
+      - '1'
+      X-Total-Pages:
+      - '1'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"parameters_conditions_attributes": [{"parameter_name": "Sensor Bias Voltage",
+      "value": "200.0"}, {"parameter_name": "Pixels X", "value": "512"}, {"parameter_name":
+      "Pixels Y", "value": "128"}, {"parameter_name": "Memory cells", "value": "352"},
+      {"parameter_name": "Acquisition rate", "value": "1.1"}, {"parameter_name": "Gain
+      setting", "value": "0"}]}'
+    headers:
+      Accept:
+      - application/json; version=2
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '353'
+      User-Agent:
+      - EXtra/2024.1.58+56cd5fc
+      content-type:
+      - application/json
+    method: GET
+    uri: http://exflcalproxy.desy.de:8080/api/calibration_constant_versions/get_by_detector_conditions?detector_identifier=HED_DET_AGIPD65K1&calibration_id=%5B20%2C+19%5D&karabo_da=&event_at=2024-03-22T17%3A19%3A15.965988%2B00%3A00&pdu_snapshot_at=2024-03-22T17%3A19%3A15.965988%2B00%3A00
+  response:
+    body:
+      string: '[]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 22 Mar 2024 17:41:47 GMT
+      Etag:
+      - W/"4f53cda18c2baa0c0354bb5f9a3ecbe5"
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=16070400; includeSubDomains
+      Vary:
+      - Origin
+      Via:
+      - HTTP/1.1 xfel_oauth_proxy
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R)
+      X-Request-Id:
+      - 41852639-9ccd-49fb-918d-4266c3feeda3
+      X-Runtime:
+      - '0.464551'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -255,6 +255,9 @@ def test_AGIPD_funky_numbering():
     assert isinstance(
         agipd_cd["Offset"]["HED_DET_AGIPD65K1/DET/8CH0:xtdf"], SingleConstant
     )
+    assert agipd_cd.select_modules(
+        source_names=["HED_DET_AGIPD65K1/DET/8CH0:xtdf"]
+    ).module_nums == [0]
 
     # Need constants created after I set the module number to test from_report
     # For this detector, that means darks newer than 2024-02-23

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -14,13 +14,14 @@ from extra.calibration import (
     SingleConstant,
 )
 
+
 # These tests all use saved HTTP responses by default (with pytest-recording).
 # To ignore these & use exflcalproxy, run pytest with the --disable-recording flag.
 # To update the saved cassettes from exflcalproxy, pass --record-mode=rewrite.
 
 
 def drop_cookie_header(response):
-    response['headers'].pop('Set-Cookie', None)
+    response["headers"].pop("Set-Cookie", None)
     return response
 
 
@@ -63,6 +64,7 @@ def test_AGIPD_CalibrationData_metadata():
     assert bva == "2022-09-02T07:42:33.000+02:00"
     metadata = agipd_cd["Offset", "AGIPD00"].metadata_dict()
     assert metadata["begin_validity_at"] == bva
+
 
 @pytest.mark.vcr
 def test_AGIPD_merge():
@@ -207,11 +209,11 @@ def test_LPD_constant_missing():
 @pytest.mark.vcr
 def test_JUNGFRAU_constant():
     cond = JUNGFRAUConditions(
-        sensor_bias_voltage=90.,
+        sensor_bias_voltage=90.0,
         memory_cells=1,
-        integration_time=400.,
+        integration_time=400.0,
         gain_setting=0,
-        sensor_temperature=291.,
+        sensor_temperature=291.0,
     )
     jf_cd = CalibrationData.from_condition(
         cond,
@@ -244,12 +246,15 @@ def test_AGIPD_funky_numbering():
     )
     agipd_cd = CalibrationData.from_condition(
         cond,
-        'HED_DET_AGIPD65K1',
+        "HED_DET_AGIPD65K1",
         event_at=datetime(2024, 3, 22, 17, 19, 15, 965988, tzinfo=timezone.utc),
     )
-    assert agipd_cd.aggregator_names == ['AGIPD08']
+    assert agipd_cd.aggregator_names == ["AGIPD08"]
     assert agipd_cd.module_nums == [0]
     assert agipd_cd.source_names == ["HED_DET_AGIPD65K1/DET/8CH0:xtdf"]
+    assert isinstance(
+        agipd_cd["Offset"]["HED_DET_AGIPD65K1/DET/8CH0:xtdf"], SingleConstant
+    )
 
     # Need constants created after I set the module number to test from_report
     # For this detector, that means darks newer than 2024-02-23


### PR DESCRIPTION
CalCat now allows specifying a source_name_pattern for detectors, such as `'HED_DET_AGIPD65K1/DET/{modno+8}CH0:xtdf'`. With this, we can expose source names as yet another way to describe detector modules.