### PR TITLE
Some minor improvements to generic pulse components

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,6 +18,8 @@
 Added:
 
 - Empty trains can now optionally be included when determining constant pulse patterns via [XrayPulses.is_constant_pattern()][extra.components.XrayPulses.is_constant_pattern] (!156).
+- Check whether any pulse patterns are interleaved with `is_interleaved_with()` or directly SA1/SA3 with `is_sa1_interleaved_with_sa3()` (!155).
+- Obtain [MachinePulses][extra.components.MachinePulses] from any other timeserver-based pulse components directly via `machine_pulses()` or get machine repetition rate directly from `machine_repetition_rate()` (!155).
 - A helper function named [fit_gaussian()][extra.utils.fit_gaussian] (!131).
 
 Fixed:

--- a/src/extra/components/pulses.py
+++ b/src/extra/components/pulses.py
@@ -333,6 +333,58 @@ class PulsePattern:
             return True
 
 
+    def is_interleaved_with(self, other: PulsePattern) -> Optional[bool]:
+        """Check whether pulses are interleaved with other pattern.
+
+        This method returns True if and only if it can safely determine
+        that the pulse pattern described by this component and the
+        passed component are interleaved, and False if and only if it is
+        clear they are not interleaved. In all other cases, the pulses
+        may or may not be interleaved and None is returned.
+
+        Returns:
+            (bool or None) Whether pulses are interleaved or None if the
+                pulse patterns do not allow the determination.
+        """
+
+        for (_, self_pids), (_, other_pids) in zip(
+            self.pulse_ids(copy=False).groupby(level=0),
+            other.pulse_ids(copy=False).groupby(level=0)
+        ):
+            self_num = len(self_pids)
+            other_num = len(other_pids)
+
+            if self_num == 0 or other_num == 0:
+                # No statement can be drawn from missing pulses.
+                continue
+
+            self_first_pulse = self_pids.min()
+            other_first_pulse = other_pids.min()
+
+            if self_num > 1 and other_num > 1:
+                # Multiple pulses in both self and other.
+
+                if self_first_pulse < other_first_pulse:
+                    # self early, interleaved <=> other starts within self
+                    return self_pids.max() > other_first_pulse
+                else:
+                    # other early, interleaved <=> self starts within other
+                    return other_pids.max() > self_first_pulse
+
+            elif self_num == 1 and other_num > 1:
+                # Single pulse in self, but multiple in other.
+                if other_first_pulse < self_first_pulse:
+                    # other early, interleaved <=> self is within other
+                    return other_pids.max() > self_first_pulse
+
+            elif self_num > 1 and other_num == 1:
+                # Multiple pulses in self, but single in other.
+                if self_first_pulse < other_first_pulse:
+                    # self early, interleaved <=> other is within self
+                    return self_pids.max() > other_first_pulse
+
+        return  # Reached in case of *maybe*
+
     def pulse_counts(self, labelled=True):
         """Get number of pulses per train.
 
@@ -847,6 +899,34 @@ class TimeserverPulses(PulsePattern):
     def machine_repetition_rate(self) -> float:
         """Actual machine repetition rate."""
         return self.machine_pulses().pulse_repetition_rates().min()
+
+    @lru_cache
+    def is_sa1_interleaved_with_sa3(self) -> Optional[bool]:
+        """Check whether SASE1 and SASE3 pulses are interleaved.
+
+        Due to their unique geometry, the pulses of the SASE1 and SASE3
+        beamlines can either occur after each other on the pulse train
+        or be interleaved. Here, each beamline generally receives their
+        first pulse directly after each other, with their relative pulse
+        patterns following afterwards in a back-and-forth fashion.
+
+        This method returns True if and only if it can be safely
+        determined the SA1 and SA3 pulses are intereavled, and False if
+        and only if it is clear they are not interleaved. In all other
+        cases, the pulses may or may not be interleaved and None is
+        returned.
+
+        Returns:
+            (bool or None) Whether SA1 and SA3 are interleaved or None
+                if the pulse patterns do not allow the determination.
+        """
+
+        sa1_pulses = XrayPulses(None, self._source, sase=1) \
+            if self._sase != 1 else self
+        sa3_pulses = XrayPulses(None, self._source, sase=3) \
+            if self._sase != 3 else self
+
+        return sa1_pulses.is_interleaved_with(sa3_pulses)
 
 
 class XrayPulses(TimeserverPulses):

--- a/src/extra/components/pulses.py
+++ b/src/extra/components/pulses.py
@@ -604,7 +604,8 @@ class TimeserverPulses(PulsePattern):
         if source is None:
             source = self._find_pulsepattern_source(data)
 
-        sd = data[source]
+        # Also support SourceData objects for internal use.
+        sd = data[source] if not isinstance(source, SourceData) else source
 
         if 'maindump.pulseIds.value' in sd.keys():
             # PulsePatternDecoder source.
@@ -617,7 +618,7 @@ class TimeserverPulses(PulsePattern):
             # Timeserver source.
             self._with_timeserver = True
 
-            if ':' in source:
+            if ':' in sd.source:
                 kd = sd['data.bunchPatternTable']
             else:
                 kd = sd['bunchPatternTable']

--- a/src/extra/components/pulses.py
+++ b/src/extra/components/pulses.py
@@ -1,6 +1,7 @@
 """Interface and utilies to work with pulse-resolved data."""
 
 
+from __future__ import annotations  # to defer evaulation of annotations
 from copy import copy
 from functools import wraps
 from typing import Optional
@@ -824,6 +825,23 @@ class TimeserverPulses(PulsePattern):
                              'bunch pattern table not available')
 
         return self._key
+
+    def machine_pulses(self, **kwargs) -> MachinePulses:
+        """Get MachinePulses component for the same data.
+
+        Any additional keyword arguments are passed to the MachinePulses
+        initializer.
+
+        Returns:
+            (MachinePulses) Corresponding component using the same data
+                as this component.
+        """
+
+        return MachinePulses(None, self._source, **kwargs)
+
+    def machine_repetition_rate(self) -> float:
+        """Actual machine repetition rate."""
+        return self.machine_pulses().pulse_repetition_rates().min()
 
 
 class XrayPulses(TimeserverPulses):

--- a/tests/test_components_pulses.py
+++ b/tests/test_components_pulses.py
@@ -87,6 +87,12 @@ def test_init(mock_spb_aux_run):
         pulses.timeserver['bunchPatternTable'])
     assert pulses.sase == 1
 
+    # Construct from SourceData.
+    pulses = XrayPulses(None, source=run['ODD_TIMESERVER_NAME'], sase=1)
+    assert_equal_sourcedata(
+        pulses.timeserver,
+        run['ODD_TIMESERVER_NAME'])
+
     # Remove all timeservers, should always raise exception.
     run_no_ts = run.select('*XGM*')
 

--- a/tests/test_components_pulses.py
+++ b/tests/test_components_pulses.py
@@ -163,8 +163,7 @@ def test_pulse_mask(mock_spb_aux_run, source):
 
 @pytest.mark.parametrize('source', **pattern_sources)
 def test_is_constant_pattern(mock_spb_aux_run, source):
-    run = mock_spb_aux_run
-    pulses = XrayPulses(run, source=source)
+    pulses = XrayPulses(mock_spb_aux_run, source=source)
 
     # Default arguments (empty trains are ignored).
     assert not pulses.is_constant_pattern()
@@ -185,6 +184,16 @@ def test_is_constant_pattern(mock_spb_aux_run, source):
 
     with pytest.raises(TypeError):
         pulses.is_constant_pattern(True)
+
+
+@pytest.mark.parametrize('source', **pattern_sources)
+def test_is_interleaved(mock_spb_aux_run, source):
+    pulses = XrayPulses(mock_spb_aux_run, source=source, sase=1)
+
+    assert pulses.is_interleaved_with(pulses.machine_pulses())
+    assert not pulses.is_interleaved_with(
+        XrayPulses(mock_spb_aux_run, source=source, sase=2))
+    assert not pulses.is_sa1_interleaved_with_sa3()
 
 
 @pytest.mark.parametrize('source', **pattern_sources)


### PR DESCRIPTION
This PR collates a couple of minor changes by themselves, aimed at building on the earlier https://github.com/European-XFEL/EXtra/pull/138. The commits mostly build on top of each other, but I tried to keep them clean by focusing on a single aspect.

* 214c635a4ca87db5e451fb964ee64465fbda7ac8 Adds an undocumented method of constructing `TimeserverPulses` components by directly passing a `SourceData` object. This is used internally to construct different `PulsePattern`-based components after the fact from the same data without having its `DataCollection`.
* 3505f247241fa9e169ee35ce8c781662706ff8f9 Using the feature above, this adds a method `.machine_pulses()` to easily obtain a `MachinePulses` component from any other timeserver-related component. As this will be often used just to get the machine repetition rate, there's an even more explicit method for that.
* a8cf3a34147c2585be2e0f4c73b513c07a7b6ec5 Per request from users, this starts adding @lru_cache to some methods where applicable. Also added a warning that `PulsePattern` are expected to be immutable.
* 21142a3e3e846fd660cdae3cfebe980aaebea601 adds a generic method to detect interleaving pulse patterns, and an explicit version to conveniently check this for SA1 and SA3.