### PR TITLE
Take empty trains into account when checking for constant pulse pattern

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,7 @@
     ```
 Added:
 
+- Empty trains can now optionally be included when determining constant pulse patterns via [XrayPulses.is_constant_pattern()][extra.components.XrayPulses.is_constant_pattern] (!156).
 - A helper function named [fit_gaussian()][extra.utils.fit_gaussian] (!131).
 
 Fixed:

--- a/tests/test_components_pulses.py
+++ b/tests/test_components_pulses.py
@@ -159,8 +159,25 @@ def test_is_constant_pattern(mock_spb_aux_run, source):
     run = mock_spb_aux_run
     pulses = XrayPulses(run, source=source)
 
+    # Default arguments (empty trains are ignored).
     assert not pulses.is_constant_pattern()
     assert pulses.select_trains(np.s_[:50]).is_constant_pattern()
+
+    # Explicit handling of empty trains.
+    assert not pulses.is_constant_pattern(
+        include_empty_trains=False)
+    assert pulses.select_trains(np.s_[:50]).is_constant_pattern(
+        include_empty_trains=False)
+
+    assert not pulses.is_constant_pattern(
+        include_empty_trains=True)
+    assert not pulses.select_trains(np.s_[:50]).is_constant_pattern(
+        include_empty_trains=True)
+    assert pulses.select_trains(np.s_[10:50]).is_constant_pattern(
+        include_empty_trains=True)
+
+    with pytest.raises(TypeError):
+        pulses.is_constant_pattern(True)
 
 
 @pytest.mark.parametrize('source', **pattern_sources)


### PR DESCRIPTION
As requested via https://github.com/European-XFEL/EXtra/issues/136 (actually from instrument staff), this PR adds an optional flag to `PulsePattern.is_constant_pattern()` to optionally take empty trains into account when determining whether the pulse pattern is content. An empty train will essentially always the pattern to not be constant. To preserve the original API, they continue to be ignored by default.