### PR TITLE
Add support to align pulse-indexed data as new columns in DLD sparse data

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,7 @@
     ```
 Added:
 
+- Data indexed by pulse can now be aligned with and added as additional columns to sparse DLD data (!166).
 - Empty trains can now optionally be included when determining constant pulse patterns via [XrayPulses.is_constant_pattern()][extra.components.XrayPulses.is_constant_pattern] (!156).
 - Check whether any pulse patterns are interleaved with `is_interleaved_with()` or directly SA1/SA3 with `is_sa1_interleaved_with_sa3()` (!155).
 - Obtain [MachinePulses][extra.components.MachinePulses] from any other timeserver-based pulse components directly via `machine_pulses()` or get machine repetition rate directly from `machine_repetition_rate()` (!155).

--- a/tests/test_components_dld.py
+++ b/tests/test_components_dld.py
@@ -99,3 +99,17 @@ def test_dld_pulse_align(mock_sqs_remi_run):
     dld = DelayLineDetector(run.select_trains(np.s_[:50]), pulses=pulses)
     hits = dld.hits()
     pd.testing.assert_frame_equal(hits, all_hits.loc[np.r_[10002:10050], :])
+
+
+def test_dld_extra_columns(mock_sqs_remi_run):
+    dld = DelayLineDetector(mock_sqs_remi_run.select('*TOP*'))
+
+    # Build some data with DLD's pulse index.
+    index = dld.pulses().build_pulse_index()
+    extra = pd.Series(np.arange(len(index)), index=index)
+
+    # Get hits with extra column.
+    hits = dld.hits(extra_columns={'foo': extra})
+
+    # Check that the hit count pattern emerges.
+    assert np.all(hits['foo'][:12] == [1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 6, 7])


### PR DESCRIPTION
Adds a new keyword argument to `dld.signals()` and `dld.hits()` to take data indexed by pulse, align it with the sparse DLD data and add as a column to the signals/hits dataframe. This allows something like:

```python3
delays = OpticalLaserDelay(run).total_delays()
hits = DelayLineDetector(run).hits(extra_columns={'delay': delays})
```

This could in principle also be added to `dld.edges()` with minor modifications, but less likely to be useful at the moment.