### PR TITLE
Optionally use negative pulse indices for PPL-only DLD pulses

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,7 @@
     ```
 Added:
 
+- [DldPulses](extra.components.DldPulses) can optionally enumerate PPL-only pulses using negative indices to stay compatible with PPL-unaware data.
 - The `slowTrains` XGM property is available through
   [XGM.slow_train_energy()][extra.components.XGM.slow_train_energy] (!162).
 - [XGM.pulse_energy()][extra.components.XGM.pulse_energy] can now take a

--- a/src/extra/components/dld.py
+++ b/src/extra/components/dld.py
@@ -15,12 +15,13 @@ class DelayLineDetector:
             needed if the data includes more than one.
         pulses (extra.components.pulses.PulsePattern, optional): Pulse
             component to pull pulse information. If omitted, it is
-            constructed from the internal trigger information.
+            constructed from the internal trigger information using any
+            remaining additional keyword argument.
     """
 
     _instrument_re = re.compile(r'^(\w{3}_\w+_DLD\d\/DET\/\w+):output?$')
 
-    def __init__(self, data, detector=None, pulses=None):
+    def __init__(self, data, detector=None, pulses=None, **kwargs):
         if detector is None:
             # Try to find detector automatically.
             detector = self._find_detector(data)
@@ -40,7 +41,7 @@ class DelayLineDetector:
         self._pulses = pulses
 
         if self._pulses is None:
-            self._pulses = self.pulses()
+            self._pulses = self.pulses(**kwargs)
 
     def __repr__(self):
         return "<{} {}>".format(
@@ -230,8 +231,10 @@ class DelayLineDetector:
 
         return new_self
 
-    def pulses(self):
+    def pulses(self, **kwargs):
         """Get pulse object based on internal triggers.
+
+        Any keyword arguments are passed to the underlying DldPulses.
 
         Returns:
             (extra.components.DldPulses): Pulse object based on
@@ -240,10 +243,10 @@ class DelayLineDetector:
 
         from .pulses import DldPulses
 
-        if isinstance(self._pulses, DldPulses):
+        if isinstance(self._pulses, DldPulses) and not kwargs:
             return self._pulses
 
-        return DldPulses(self._instrument_src)
+        return DldPulses(self._instrument_src, **kwargs)
 
     def triggers(self):
         """Get triggers as dataframe.

--- a/src/extra/components/dld.py
+++ b/src/extra/components/dld.py
@@ -184,12 +184,14 @@ class DelayLineDetector:
 
         num_per_pulse = df[df.columns[0]].groupby(
             level=df.index.names[:-1]).count()
-        dld_index = self.pulses().build_pulse_index()
+        req_index = num_per_pulse.index.names
 
         for col_name, col_data in columns.items():
+            if col_data.index.names != req_index[:len(col_data.index.names)]:
+                raise ValueError('index incompatible with dataframe')
+
             df[col_name] = (col_data
-                .reindex(dld_index)
-                .loc[num_per_pulse.index]
+                .reindex(num_per_pulse.index)
                 .repeat(num_per_pulse)
                 .to_numpy()
             )

--- a/src/extra/components/pulses.py
+++ b/src/extra/components/pulses.py
@@ -1465,25 +1465,56 @@ class DldPulses(PulsePattern):
         first_pulse_id (int, optional): Pulse ID for the first pulse,
             only used in case of missing pulse ID information in data
             and 0 by default.
+        negative_ppl_indices (bool, optional): Whether to enumerate
+            PPL-only pulses with negative indices (while keeping
+            non-negative indices for FEL-only or pumped pulses) or
+            interleave all pulses with positive indices (default).
     """
 
-    def __init__(self, detector, *, clock_ratio=None, first_pulse_id=None):
+    def __init__(self, detector, *, clock_ratio=None, first_pulse_id=None,
+                 negative_ppl_indices=False):
         super().__init__(detector, detector['raw.triggers'])
 
         self._clock_ratio = clock_ratio
         self._first_pulse_id = first_pulse_id
+        self._negative_ppl_indices = negative_ppl_indices
 
     def _get_train_ids(self):
         return np.unique(self._key.train_id_coordinates())
 
     def _get_pulse_ids(self):
         triggers = self._key.ndarray()
+        train_ids = self._key.train_id_coordinates()
+
+        if self._negative_ppl_indices:
+            if 'ppl' not in triggers.dtype.fields:
+                raise ValueError('negative PPL indices only available '
+                                 'with PPL information')
+
+            pulse_indices = np.zeros(len(triggers), dtype=int)
+            prev_tid = -1
+
+            for i, tid, row in zip(range(len(triggers)), train_ids, triggers):
+                if tid != prev_tid:
+                    prev_tid = tid
+                    only_ppl_index = -1
+                    with_fel_index = 0
+
+                if row['ppl'] and not row['fel']:
+                    pulse_indices[i] = only_ppl_index
+                    only_ppl_index -= 1
+                else:
+                    pulse_indices[i] = with_fel_index
+                    with_fel_index += 1
+
+        else:
+            pulse_indices = np.concatenate([
+                np.arange(count, dtype=np.int32) for count
+                in self._key.data_counts(labelled=False)])
 
         index_levels = {
-            'trainId': self._key.train_id_coordinates(),
-            'pulseIndex': np.concatenate([
-                np.arange(count, dtype=np.int32) for count
-                in self._key.data_counts(labelled=False)]),
+            'trainId': train_ids,
+            'pulseIndex': pulse_indices,
         }
 
         if 'fel' in triggers.dtype.fields:

--- a/tests/test_components_dld.py
+++ b/tests/test_components_dld.py
@@ -113,3 +113,10 @@ def test_dld_extra_columns(mock_sqs_remi_run):
 
     # Check that the hit count pattern emerges.
     assert np.all(hits['foo'][:12] == [1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 6, 7])
+
+    # Try with wrong index.
+    index = dld.pulses().build_pulse_index(pulse_dim='pulseIndex')
+    extra = pd.Series(np.arange(len(index)), index=index)
+
+    with pytest.raises(ValueError):
+        dld.hits(extra_columns={'foo': extra})

--- a/tests/test_components_pulses.py
+++ b/tests/test_components_pulses.py
@@ -603,6 +603,18 @@ def test_dld_pulses(capsys):
     with pytest.warns():
         assert pulses.get_triggers().equals(pulses.triggers())
 
+    # Test with negative PPL indices.
+    mock_key.ndarray.return_value = triggers
+    mock_key.ndarray.return_value[:2]['ppl'] = True
+    mock_key.ndarray.return_value[:2]['fel'] = False
+    mock_key.ndarray.return_value[-2:]['ppl'] = True
+    mock_key.ndarray.return_value[-2:]['fel'] = False
+
+    pids = DldPulses(mock_source, negative_ppl_indices=True).pulse_ids()
+    np.testing.assert_equal(
+        pids.index.get_level_values('pulseIndex'),
+        np.array([-1, -2, 0, 1, 2, 3, 4, 5, -3, -4]))
+
 
 @pytest.mark.parametrize('source', **pattern_sources)
 def test_pump_probe_basic(mock_spb_aux_run, source):


### PR DESCRIPTION
The `PumpProbePulses` component and its spiritual predecessor `DldPulses` combine FEL-only, PPL-only and pumped pulses into a single consistent pattern, i.e. may have more pulses than a pure FEL pattern in the presence of PPL-only pulses.

While this is useful for analysis, it presents problems when correlating FEL-only data using enumerated indices to label pulses. The XGM component e.g. will only ever look at pulses with FEL (either FEL-only or pumped) and enumerate accordingly, being incompatible with the integrated pattern.

While this can be fixed by using global pulse IDs (i.e. referring to indices in the machine pattern table), the use of pulse indices is still often desired and/or easier to obtain. This PR adds an optional flag to `DldPulses` (only for now, can be ported to `PumpProbePulses`) to modify the enumeration behaviour:

* FEL-only and pumped pulses are enumerated without taking the PPL into account
* PPL-only pulses are _enumerated_ with negative indices, i.e. starting with -1 and counting down

The resulting indices are again compatible with PPL-unaware pulse indices, while still containing the PPL-only pulses. 

Examples:

* Four FEL pulses with two preceding PPL-only pulses:
  `0, 1, 2, 3, 4, 5` becomes `-1, -2, 0, 1, 2, 3`
* Four FEL pulses with two PPL-only pulses at start and end each
  `0, 1, 2, 3, 4, 5, 6, 7` becomes `-1, -2, 0, 1, 2, 3, -3, -4`

Also fixes a minor bug with the preceding https://github.com/European-XFEL/EXtra/pull/166 to ensure indexes are compatible, and simplifies passing custom arguments to construct the internal pulse information with `DelayLineDetector`.

 