### PR TITLE
Add Scan.split_by_steps() method

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,6 +27,7 @@ Added:
 - Check whether any pulse patterns are interleaved with `is_interleaved_with()` or directly SA1/SA3 with `is_sa1_interleaved_with_sa3()` (!155).
 - Obtain [MachinePulses][extra.components.MachinePulses] from any other timeserver-based pulse components directly via `machine_pulses()` or get machine repetition rate directly from `machine_repetition_rate()` (!155).
 - A helper function named [fit_gaussian()][extra.utils.fit_gaussian] (!131).
+- A new method [Scan.split_by_steps()][extra.components.Scan.split_by_steps] (!169).
 
 Fixed:
 

--- a/src/extra/components/utils.py
+++ b/src/extra/components/utils.py
@@ -1,3 +1,5 @@
+import sys
+
 # Source prefixes in use at each SASE.
 SASE_TOPICS = {
     1: {'SA1', 'LA1', 'SPB', 'FXE'},
@@ -23,3 +25,12 @@ def identify_sase(run):
         raise ValueError('sources from multiple SASE branches {} found, '
                          'please pass the SASE beamline explicitly'.format(
                              ', '.join(map(str, sases))))
+
+
+def _isinstance_no_import(obj, mod: str, cls: str):
+    """Check if isinstance(obj, mod.cls) without loading mod"""
+    m = sys.modules.get(mod)
+    if m is None:
+        return False
+
+    return isinstance(obj, getattr(m, cls))

--- a/tests/test_components_scan.py
+++ b/tests/test_components_scan.py
@@ -27,10 +27,11 @@ def test_scan(mock_spb_aux_run):
         Scan(motor["actualPosition"].ndarray())
 
     # Test splitting a DataCollection by scan steps
-    # TODO: generate some motor data, scan is empty at present
     steps_data = s.split_by_steps(mock_spb_aux_run)
+    assert len(s.steps) == 10
     assert len(steps_data) == len(s.steps)
     assert all(isinstance(dc, extra_data.DataCollection) for dc in steps_data)
+    assert {len(dc.train_ids) for dc in steps_data} == {9, 10}
 
     # Create fake scan to test detection
     s, steps = Scan._mkscan(20, step_length_rnd=0.5)

--- a/tests/test_components_scan.py
+++ b/tests/test_components_scan.py
@@ -4,6 +4,8 @@ import pytest
 import numpy as np
 import xarray as xr
 
+import extra_data
+
 
 def test_scan(mock_spb_aux_run):
     motor = mock_spb_aux_run["MOTOR/MCMOTORYFACE"]
@@ -23,6 +25,12 @@ def test_scan(mock_spb_aux_run):
     # And an unsupported type
     with pytest.raises(TypeError):
         Scan(motor["actualPosition"].ndarray())
+
+    # Test splitting a DataCollection by scan steps
+    # TODO: generate some motor data, scan is empty at present
+    steps_data = s.split_by_steps(mock_spb_aux_run)
+    assert len(steps_data) == len(s.steps)
+    assert all(isinstance(dc, extra_data.DataCollection) for dc in steps_data)
 
     # Create fake scan to test detection
     s, steps = Scan._mkscan(20, step_length_rnd=0.5)


### PR DESCRIPTION
To split any of our objects with a `.select_trains()` method, as well as suitable DataArrays. E.g. we could have used this recently for FXE to split JUNGFRAU data into scan steps before loading it.

This is pretty trivial to do without an extra method, but it seems like a nice convenience, and I think it fits neatly with `bin_by_steps`. I also hope that we can later optimise it to avoid the N-squared performance we had with `.split_trains()` on long runs in the past.