### PR TITLE
Add support to filter DLD hits for reconstruction method while loading

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,7 +17,8 @@
     ```
 Added:
 
-- [DldPulses](extra.components.DldPulses) can optionally enumerate PPL-only pulses using negative indices to stay compatible with PPL-unaware data.
+- Hits obtained via [DelayLineDetector.hits()][extra.components.DelayLineDetector.hits] can now optionally be restricted to hits reconstructed with a certain method. (!170)
+- [DldPulses](extra.components.DldPulses) can optionally enumerate PPL-only pulses using negative indices to stay compatible with PPL-unaware data. (!167)
 - The `slowTrains` XGM property is available through
   [XGM.slow_train_energy()][extra.components.XGM.slow_train_energy] (!162).
 - [XGM.pulse_energy()][extra.components.XGM.pulse_energy] can now take a

--- a/src/extra/components/dld.py
+++ b/src/extra/components/dld.py
@@ -167,7 +167,8 @@ class DelayLineDetector:
         if entry_level is not None:
             index_df[entry_level] = np.flatnonzero(finite_mask) % num_rows
 
-        return pd_cls(raw[finite_mask], pd.MultiIndex.from_frame(index_df))
+        return pd_cls(np.ascontiguousarray(raw[finite_mask]),
+                      pd.MultiIndex.from_frame(index_df))
 
     def _insert_aligned_columns(self, df, columns):
         """Add pulse-indexed data to reduced dataframe.

--- a/src/extra/components/dld.py
+++ b/src/extra/components/dld.py
@@ -9,6 +9,15 @@ import pandas as pd
 class DelayLineDetector:
     """Interface for processed delay line detector data.
 
+    Raw analog data from quad and hex delay line detectors acquired with
+    GHz digitizers can be reconstructed into hits by the European XFEL
+    offline processing machinery. This component allows convenient
+    access to the resulting sparse data as pulse-labeled pandas series
+    and dataframes.
+
+    Note that this component is not able to access data saved by the
+    proprietary SurfaceConcepts TDC integration.
+
     Args:
         data (extra_data.DataCollection): Data to access DLD data from.
         detector (str, optional): Source name of the detector, only

--- a/tests/test_components_dld.py
+++ b/tests/test_components_dld.py
@@ -120,3 +120,16 @@ def test_dld_extra_columns(mock_sqs_remi_run):
 
     with pytest.raises(ValueError):
         dld.hits(extra_columns={'foo': extra})
+
+
+def test_dld_max_method(mock_sqs_remi_run):
+    dld = DelayLineDetector(mock_sqs_remi_run.select('*TOP*'))
+    all_hits = dld.hits(max_method=None)
+    all_signals = dld.signals(max_method=None)
+
+    for m in range(20):
+        mask = all_hits['m'] <= m
+        pd.testing.assert_frame_equal(
+            all_hits[mask], dld.hits(max_method=m))
+        pd.testing.assert_frame_equal(
+            all_signals[mask], dld.signals(max_method=m))


### PR DESCRIPTION
The DLD reconstruction performed as part of the calibration pipeline assigns a reconstruction method to each hit, an enum value denoting which signals were successfully paired to reconstruct the hit ranging from 0 (perfect) to 19 (mostly guessing). This is well documented in the processing reports with various plots.

While the dataframe loaded via `DelayLineDetector.hits` can easily be loaded filtered manually, it is very common to only consider unrisky reconstructions during regular analysis. Also, in some scenarios there can be many badly reconstructed hits with only a few good ones, making all following operations slower even if those hits are not interesting.

This PR adds support to filter by reconstruction method early while masking the input data for finite entries. Any subsequent indexing operation will therefore only operate on the desired rows. 