### PR TITLE
Support more types for DLD dataframe extra columns

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,7 +24,7 @@ Added:
 - [XGM.pulse_energy()][extra.components.XGM.pulse_energy] can now take a
   `series=True` argument to return a 1D [Series][pandas.Series] instead of a 2D
   [DataArray][xarray.DataArray] (!162).
-- Data indexed by pulse can now be aligned with and added as additional columns to sparse DLD data (!166).
+- Data indexed by pulse or train can now be aligned with and added as additional columns to sparse DLD data (!166, !173).
 - [OpticalLaserDelay][extra.components.OpticalLaserDelay] to obtain the time delays between FEL and optical laser pulses (!165).
 - Empty trains can now optionally be included when determining constant pulse patterns via [XrayPulses.is_constant_pattern()][extra.components.XrayPulses.is_constant_pattern] (!156).
 - Check whether any pulse patterns are interleaved with `is_interleaved_with()` or directly SA1/SA3 with `is_sa1_interleaved_with_sa3()` (!155).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,6 +133,7 @@ def multi_xgm_run():
 def mock_sqs_remi_directory():
     sources = [
         Timeserver('SQS_RR_UTC/TSYS/TIMESERVER'),
+        PulsePatternDecoder('SQS_RR_UTC/TSYS/PP_DECODER'),
         XGM('SA3_XTD10_XGM/XGM/DOOCS'),
         ReconstructedDld('SQS_REMI_DLD6/DET/TOP'),
         ReconstructedDld('SQS_REMI_DLD6/DET/BOTTOM'),


### PR DESCRIPTION
Building on https://github.com/European-XFEL/EXtra/pull/166, this PR relaxes the type requirements a bit to work with both pulse- and train-resolved data in `pd.Series`, `xr.DataArray` or directly `KeyData` objects. Naturally the pulse index must be *compatible*, i.e. use the same first two columns.