### PR TITLE
Add parameter to get only FEL or only pump laser mask from PumpProbePulses

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -30,6 +30,8 @@ Added:
 - Obtain [MachinePulses][extra.components.MachinePulses] from any other timeserver-based pulse components directly via `machine_pulses()` or get machine repetition rate directly from `machine_repetition_rate()` (!155).
 - A helper function named [fit_gaussian()][extra.utils.fit_gaussian] (!131).
 - A new method [Scan.split_by_steps()][extra.components.Scan.split_by_steps] (!169).
+- [PumpProbePulses.pulse_mask][extra.components.PumpProbePulses.pulse_mask] now
+  has an option to give a mask for only FEL or only pump laser pulses (!174).
 
 Fixed:
 

--- a/src/extra/components/pulses.py
+++ b/src/extra/components/pulses.py
@@ -281,9 +281,6 @@ class PulsePattern:
 
         Returns:
             (xarray.DataArray or numpy.ndarray):
-
-        Returns:
-            (numpy.ndarray or pandas.Series):
         """
 
         mask = self._get_pulse_mask()
@@ -1445,6 +1442,16 @@ class PumpProbePulses(XrayPulses, OpticalLaserPulses):
         table but only contains boolean flags whether a given pulse
         was present in this pattern.
 
+        For instance, to see whether each FEL pulse has a corresponding pump
+        laser pulse in a consistent pulse pattern:
+
+        ```python
+        ppl_on = ppp.select_trains(0).pulse_mask(field='ppl').squeeze()
+        fel_on = ppp.select_trains(0).pulse_mask(field='fel').squeeze()
+
+        fel_pulse_is_pumped = ppl_on[fel_on]
+        ```
+
         Args:
             labelled (bool, optional): Whether a labelled xarray
                 DataArray (default) or unlabelled numpy array is
@@ -1455,9 +1462,6 @@ class PumpProbePulses(XrayPulses, OpticalLaserPulses):
 
         Returns:
             (xarray.DataArray or numpy.ndarray):
-
-        Returns:
-            (numpy.ndarray or pandas.Series):
         """
         bitfield = TimeserverPulses.pulse_mask(self, labelled=labelled)
         if field is None:

--- a/src/extra/components/pulses.py
+++ b/src/extra/components/pulses.py
@@ -1438,10 +1438,36 @@ class PumpProbePulses(XrayPulses, OpticalLaserPulses):
 
         return flags
 
-    @wraps(PulsePattern.pulse_mask)
-    def pulse_mask(self, labelled=True):
-        return TimeserverPulses.pulse_mask(
-            self, labelled=labelled).astype(bool)
+    def pulse_mask(self, labelled=True, field=None):
+        """Get boolean pulse mask.
+
+        The returned mask has the same shape as the full bunch pattern
+        table but only contains boolean flags whether a given pulse
+        was present in this pattern.
+
+        Args:
+            labelled (bool, optional): Whether a labelled xarray
+                DataArray (default) or unlabelled numpy array is
+                returned.
+            field (str, optional): 'fel'/'ppl' to mark only FEL or only pump
+                laser pulses in the returned array. By default, pulses are True
+                whether either an FEL pulse or a PPL pulse occured.
+
+        Returns:
+            (xarray.DataArray or numpy.ndarray):
+
+        Returns:
+            (numpy.ndarray or pandas.Series):
+        """
+        bitfield = TimeserverPulses.pulse_mask(self, labelled=labelled)
+        if field is None:
+            return bitfield.astype(bool)
+        elif field == 'fel':
+            return (bitfield & 1).astype(bool)
+        elif field == 'ppl':
+            return (bitfield & 2).astype(bool)
+        else:
+            raise ValueError(f"{field=!r} parameter was not 'fel'/'ppl'/None")
 
 
 class DldPulses(PulsePattern):

--- a/tests/test_components_pulses.py
+++ b/tests/test_components_pulses.py
@@ -651,17 +651,26 @@ def test_pump_probe_basic(mock_spb_aux_run, source):
     # any pulses and trains without FEL pulses.
     # Requires use of bunch_table_position to avoid extrapolating FEL
     # pulses at the beginning of the run.
-    mask = PumpProbePulses(
+    pulses2 = PumpProbePulses(
         run, source=source, bunch_table_position=1001
-    ).pulse_mask(labelled=False)
+    )
+    mask = pulses2.pulse_mask(labelled=False)
+    fel_mask = pulses2.pulse_mask(labelled=False, field='fel')
+    ppl_mask = pulses2.pulse_mask(labelled=False, field='ppl')
 
     assert not mask[:5].any()  # No pulses at all.
+    assert not fel_mask[:5].any()
+    assert not ppl_mask[:5].any()
 
     # No FEL pulses but PPL pulses.
     assert not mask[5:10, 1000:1300:6].any() and mask[5:10, 1001:1301:6].all()
+    assert not fel_mask[5:10, 1000:1301].any()
+    assert ppl_mask[5:10, 1001:1301:6].all()
 
     # FEL and PPL pulses.
     assert mask[10, 1000:1300:6].all() and mask[10, 1001:1301:6].all()
+    assert fel_mask[10, 1000:1300:6].all() and not fel_mask[10, 1001:1301:6].any()
+    assert not ppl_mask[10, 1000:1300:6].any() and ppl_mask[10, 1001:1301:6].all()
 
     # Is constant pattern?
     assert not pulses.is_constant_pattern()


### PR DESCRIPTION
This should allow easier ways to get information like 'which FEL pulses have a corresponding optical laser pulse':


```python
ppl_on = ppp.select_trains(0).pulse_mask(field='ppl', labelled=False).squeeze()
fel_on = ppp.select_trains(0).pulse_mask(field='fel', labelled=False).squeeze()

fel_pulse_is_pumped = ppl_on[fel_on]
```

(I also explored another option in the branch [`pumpprobe-dataframe`](https://github.com/European-XFEL/EXtra/compare/pumpprobe-dataframe); I think this variant fits in better with the existing API, with less extra stuff to learn.)
