### PR TITLE
Expose extra_data components in extra.components

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,6 +19,7 @@
 Added:
 - [CookieboxCalibration][extra.recipes.CookieboxCalibration] to calibrate data from eTOFs after taking a calibration run (!284).
 - [Grating2DCalibration][extra.recipes.Grating2DCalibration] to calibrate data from a 2D grating detector (!284).
+- Exposed detector data components from `extra_data` in `extra.components` (AGIPD1M, AGIPD500K, DSSC1M, JUNGFRAU, LPD1M).
 
 Fixed:
 - [AdqRawChanne][extra.components.AdqRawChannel] now properly enumerates channels starting with 1 rather than 0 as in the Karabo device.

--- a/src/extra/components/__init__.py
+++ b/src/extra/components/__init__.py
@@ -9,3 +9,6 @@ from .timepix import Timepix3  # noqa
 from .las import OpticalLaserDelay  # noqa
 from .adq import AdqRawChannel  # noqa
 from .detector_motors import AGIPD1MQuadrantMotors, JF4MHalfMotors  # noqa
+
+# Also expose extra_data's components for multi-module detectors here
+from extra_data.components import *


### PR DESCRIPTION
This would avoid people needing to know that some component classes belong to EXtra and others to EXtra-data, if they can import all of them from `extra.components`.

On the other hand, it could create more confusion if someone ends up with an older EXtra-data package and a newer EXtra, or vice versa, because these classes appear to be part of EXtra, but actually aren't.

I don't have a strong preference, but I figured a PR was a good way to have the discussion.