### PR TITLE
Deprecate pulse dimension time in favor of pulseTime

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -35,6 +35,7 @@ Added:
   has an option to give a mask for only FEL or only pump laser pulses (!174).
 - [BadPixels](extra.calibration.BadPixels) flag values for interpreting masks
   in corrected detector data (!172).
+- Deprecate pulse dimension `time` in favor of `pulseTime` (!178).
 
 Fixed:
 

--- a/src/extra/components/dld.py
+++ b/src/extra/components/dld.py
@@ -83,8 +83,8 @@ class DelayLineDetector:
 
         Args:
             kd (extra_data.KeyData): KeyData object to align to.
-            pulse_dim ({pulseId, pulseIndex, time}, optional): Label
-                for pulse dimension, pulse ID by default.
+            pulse_dim ({pulseId, pulseIndex, pulseTime}, optional):
+                Label for pulse dimension, pulse ID by default.
 
         Returns:
             (pandas.Index or None): Index from internal pulses component
@@ -319,8 +319,8 @@ class DelayLineDetector:
             channel_index (bool, optional): Whether to insert the edge
                 channel as index level and return Series object
                 (default), or as column and return DataFrame object.
-            pulse_dim ({pulseId, pulseIndex, time}, optional): Label
-                for pulse dimension, pulse ID by default.
+            pulse_dim ({pulseId, pulseIndex, pulseTime}, optional):
+                Label for pulse dimension, pulse ID by default.
 
         Returns:
             (pd.Series or pd.DataFrame): Raw edge positions as Series
@@ -360,8 +360,8 @@ class DelayLineDetector:
         [hits()](extra.components.DelayLineDetector.hits()).
 
         Args:
-            pulse_dim ({pulseId, pulseIndex, time}, optional): Label
-                for pulse dimension, pulse ID by default.
+            pulse_dim ({pulseId, pulseIndex, pulseTime}, optional):
+                Label for pulse dimension, pulse ID by default.
             extra_columns (dict): Mapping of column name to labeled 1D
                 data to insert, may be pandas series, xarray DataArray
                 or KeyData. Must be re-indexable by internal train or
@@ -402,8 +402,8 @@ class DelayLineDetector:
         for more information
 
         Args:
-            pulse_dim ({pulseId, pulseIndex, time}, optional): Label
-                for pulse dimension, pulse ID by default.
+            pulse_dim ({pulseId, pulseIndex, pulseTime}, optional):
+                Label for pulse dimension, pulse ID by default.
             extra_columns (dict): Mapping of column name to labeled 1D
                 data to insert, may be pandas series, xarray DataArray
                 or KeyData. Must be re-indexable by internal train or

--- a/src/extra/components/las.py
+++ b/src/extra/components/las.py
@@ -299,8 +299,8 @@ class OpticalLaserDelay:
                 or not (default). As the trigger delay is only recorded
                 by train, identical values are returned for every pulse
                 if enabled.
-            pulse_dim ({pulseId, pulseIndex, time}, optional): Label
-                for pulse dimension, pulse ID by default.
+            pulse_dim ({pulseId, pulseIndex, pulseTime}, optional):
+                Label for pulse dimension, pulse ID by default.
 
         Returns:
             (pandas.Series or numpy.ndarray): Time delay from electronic
@@ -321,8 +321,8 @@ class OpticalLaserDelay:
                 or not (default). As the stage delay is only recorded
                 by train, identical values are returned for every pulse
                 if enabled.
-            pulse_dim ({pulseId, pulseIndex, time}, optional): Label
-                for pulse dimension, pulse ID by default.
+            pulse_dim ({pulseId, pulseIndex, pulseTime}, optional):
+                Label for pulse dimension, pulse ID by default.
 
         Returns:
             (pandas.Series or numpy.ndarray): Time delay from delay line
@@ -343,8 +343,8 @@ class OpticalLaserDelay:
             by_pulse (bool, optional): Whether data is returned by pulse
                 (default) or not. If disabled, the train value is the
                 average over all pulses.
-            pulse_dim ({pulseId, pulseIndex, time}, optional): Label
-                for pulse dimension, pulse ID by default.
+            pulse_dim ({pulseId, pulseIndex, pulseTime}, optional):
+                Label for pulse dimension, pulse ID by default.
 
         Returns:
             (pandas.Series or numpy.ndarray): Time delay from BAM
@@ -387,8 +387,8 @@ class OpticalLaserDelay:
             by_pulse (bool, optional): Whether data is returned by pulse
                 or not. By default, it is returned by pulse whenever BAM
                 data is enabled and by train otherwise.
-            pulse_dim ({pulseId, pulseIndex, time}, optional): Label
-                for pulse dimension, pulse ID by default.
+            pulse_dim ({pulseId, pulseIndex, pulseTime}, optional):
+                Label for pulse dimension, pulse ID by default.
 
         Returns:
             (pandas.Series or numpy.ndarray): Total time delay, indexed
@@ -418,8 +418,8 @@ class OpticalLaserDelay:
             by_pulse (bool, optional): Whether data is returned by pulse
                 or not. By default, it is returned by pulse whenever BAM
                 data is enabled and by train otherwise.
-            pulse_dim ({pulseId, pulseIndex, time}, optional): Label
-                for pulse dimension, pulse ID by default.
+            pulse_dim ({pulseId, pulseIndex, pulseTime}, optional):
+                Label for pulse dimension, pulse ID by default.
 
         Returns:
             (pandas.DataFrame): Time delay by source, indexed by train

--- a/src/extra/components/pulses.py
+++ b/src/extra/components/pulses.py
@@ -519,8 +519,8 @@ class PulsePattern:
         """Get a multi-level index for pulse-resolved data.
 
         Args:
-            pulse_dim ({pulseId, pulseIndex, time}, optional): Label
-                for pulse dimension, pulse ID by default.
+            pulse_dim ({pulseId, pulseIndex, pulseTime}, optional):
+                Label for pulse dimension, pulse ID by default.
             include_extra_dims (bool, optional): Whether to include any
                 additional dimensions of this particular implementation
                 beyond train ID and pulse dimension.
@@ -539,13 +539,17 @@ class PulsePattern:
         elif pulse_dim == 'pulseIndex':
             index_levels[pulse_dim] = pulse_ids.index.get_level_values(
                 'pulseIndex')
-        elif pulse_dim == 'time':
+        elif pulse_dim in {'time', 'pulseTime'}:
+            if pulse_dim == 'time':
+                warn('Use `pulseTime` instead of `time`',
+                     DeprecationWarning, stacklevel=2)
+
             index_levels[pulse_dim] = np.concatenate([
                 pids - pids.iloc[0] for _, pids
                 in pulse_ids.groupby(level=0)]) / self.bunch_repetition_rate
         else:
             raise ValueError('pulse_dim must be one of `pulseId`, '
-                             '`pulseIndex`, `time`')
+                             '`pulseIndex`, `pulseTime`')
 
         if include_extra_dims:
             index_levels.update({name: pulse_ids.index.get_level_values(name)

--- a/tests/test_components_pulses.py
+++ b/tests/test_components_pulses.py
@@ -372,7 +372,7 @@ def test_build_pulse_index(mock_spb_aux_run, source):
     np.testing.assert_equal(pulse_indices[:2000], np.tile(np.r_[:50], 40))
     np.testing.assert_equal(pulse_indices[2000:], np.tile(np.r_[:25], 50))
 
-    times = pulses.build_pulse_index('time').get_level_values(1)
+    times = pulses.build_pulse_index('pulseTime').get_level_values(1)
     rate = pulses.bunch_repetition_rate
     np.testing.assert_allclose(
         times[:2000], np.tile((np.r_[1000:1300:6] - 1000) / rate, 40))


### PR DESCRIPTION
In hindsight, optionally using the name `time` in the pulse index was kind of bound for name collisions. I would therefore rather sooner than later deprecate it in favor of `pulseTime`. This MR will continue to allow `time` to work, but no longer documents it and raises a warning if used.