### PR TITLE
fix: convert conditions for CALCAT to float or string as expected.

### DIFF
--- a/src/extra/calibration.py
+++ b/src/extra/calibration.py
@@ -525,9 +525,19 @@ class CalibrationData(Mapping):
             (dict) Operating condition for use in CalCat API.
         """
 
+        def to_float_or_string(value):
+            """CALCAT expects data to either be float or a string."""
+            try:  # Any digit or boolean
+                return float(value)
+            except:
+                return str(value)
+
         return {
             "parameters_conditions_attributes": [
-                {"parameter_name": k, "value": str(v)} for k, v in condition.items()
+                {
+                    "parameter_name": k,
+                    "value": to_float_or_string(v)
+                } for k, v in condition.items()
             ]
         }
 


### PR DESCRIPTION
This Pull request is connected to https://git.xfel.eu/calibration/pycalibration/-/merge_requests/1019


CALCAT converts conditions values to float if digit and to string otherwise. This achieves the same goal so the application code solves the issue in case a boolean condition is given. Currently, it will be sent as a string, and a wrong value is used in CALCAT but with PR it will be converted to floats.