### PR TITLE
Fix using a labelled series to compute pulse distances

### DIFF
--- a/src/extra/components/adq.py
+++ b/src/extra/components/adq.py
@@ -655,7 +655,7 @@ class AdqRawChannel:
                 pulse_period = AdqRawChannel._bunch_repetition_rate \
                     / repetition_rate
             elif pulse_ids is None and self._pulses is not None:
-                pulse_ids = self._pulses.peek_pulse_ids()
+                pulse_ids = self._pulses.peek_pulse_ids(labelled=False)
 
             if pulse_ids is not None:
                 # May either be passed directly or come from pulses


### PR DESCRIPTION
Before someone states the obvious, this is why one should have unit tests.

Turns out substracting two pandas series with different indices from each other gives unexpected results (`{nan, 0.0}` rather than a finite number).