### PR TITLE
Add missing EdgeInterpolation docs and various other text fixes

### DIFF
--- a/docs/signal.md
+++ b/docs/signal.md
@@ -2,15 +2,20 @@
 This module holds various methods to do signal processing.
 
 
-## Interpolation
-
-::: extra.signal.sinc_interpolate
-
-
 ## Fast timing discrimination
-
-::: extra.signal.cfd
 
 ::: extra.signal.dled
 
+::: extra.signal.cfd
+
+::: extra.signal.EdgeInterpolation
+    options:
+      members: []
+      docstring_section_style: "list"
+
 ::: extra.signal.config_ftd_interpolation
+
+
+## Interpolation
+
+::: extra.signal.sinc_interpolate


### PR DESCRIPTION
I missed including the `EdgeInterpolation` enum in the docs, and took the opportunity to expand a bit more on it as well as fix some other miscellaneous docs in the same module.