### PR TITLE
Fix extra_compile_args in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,8 @@ from setuptools import Extension, setup
 
 cython_ext_kw = dict(
     include_dirs=[np.get_include()],
-    compile_args = ['-g0', '-O3', '-fpic', '-frename-registers',
-                    '-ftree-vectorize']
+    extra_compile_args=['-g0', '-O3', '-fpic', '-frename-registers',
+                        '-ftree-vectorize']
 )
 
 setup(


### PR DESCRIPTION
Frankly I have no idea if this is a legacy key, or I simply messed things up when I added more Cython extensions. But it should definitely be `extra_compile_args`.