### PR TITLE
Add Python 3.12 to CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - name: Checkout


### PR DESCRIPTION
I don't think we have any plans to use Python 3.12 soon, but 3.12 seems to be surprisingly breaking so I'd like to start testing on it early.