### PR TITLE
fix(dependency): add tabulate (used in markdown_table)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -55,6 +55,7 @@ Fixed:
   the XGM will rely only on the fast data to find the number of pulses in
   `.pulse_energy()` (!153).
 - Attempt to convert calibration condition values to floats before defaulting to strings. This prevents misinterpretation of boolean values as strings (e.g., "True") (!193).
+- Add tabulate to the package dependencies.
 
 ## [2024.1.1]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "pint",
     "requests",
     "scipy",
+    "tabulate",
 ]
 requires-python = ">=3.9"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ test = [
     "pytest",
     "pytest-cov",
     "pytest-recording",
-    "tabulate",
 ]
 docs = [
     "mkdocs-material",


### PR DESCRIPTION
The calibration method [markdown_table](https://github.com/European-XFEL/EXtra/blob/1c3febdb8ec7340898ae0b55e4c8f9e264bfaa5c/src/extra/calibration.py#L811) imports tabulate.


This MR includes the missing dependency for tabulate

