### PR TITLE
Fit a unnormalized Gaussian by default in `fit_gaussian()`

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,8 +17,15 @@
     ```
 
 Fixed:
+
 - Karabacon 3.0.10 is now supported by the [Scantool][extra.components.Scantool]
   (!212).
+
+Changed:
+
+- [`gaussian()`][extra.utils.gaussian] has a new `norm` parameter to allow
+  disabling normalization, which [`fit_gaussian()`][extra.utils.fit_gaussian] will
+  use by default (!221).
 
 ## [2024.1.2]
 Added:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,7 +13,7 @@ def test_scaled_imshow():
 def test_fit_gaussian():
     # Test with auto-generated xdata and nans/infs
     params = [0, 1, 20, 5]
-    data = gaussian(np.arange(100), *params)
+    data = gaussian(np.arange(100), *params, norm=False)
     data[50] = np.nan
     data[51] = np.inf
     popt = fit_gaussian(data)
@@ -22,6 +22,6 @@ def test_fit_gaussian():
     # Test with provided xdata
     params = [0, 1, 0.5, 0.2]
     xdata = np.arange(0, 1, 0.01)
-    data = gaussian(xdata, *params)
+    data = gaussian(xdata, *params, norm=False)
     popt = fit_gaussian(data, xdata=xdata)
     assert np.allclose(popt, params)


### PR DESCRIPTION
Getting back a normalized amplitude is a bit unexpected when you're fitting physical data.

It's a bit annoying to work around this so I'll merge it later tonight if there's no objections. Technically it is a bit breaking but I'm willing to accept that since it's fairly early in the cycle and this is a decent improvement.