### PR TITLE
Add A_sign parameter for fit_gaussian()

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -26,7 +26,7 @@ Changed:
 - [`gaussian()`][extra.utils.gaussian] has a new `norm` parameter to allow
   disabling normalization, which [`fit_gaussian()`][extra.utils.fit_gaussian] will
   use by default (!221).
-- [`fit_gaussian()`][extra.utils.fit_gaussian] has a new `Asign` parameter to
+- [`fit_gaussian()`][extra.utils.fit_gaussian] has a new `A_sign` parameter to
   specify the expected orientation of the peak (!222).
 
 ## [2024.1.2]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -26,6 +26,8 @@ Changed:
 - [`gaussian()`][extra.utils.gaussian] has a new `norm` parameter to allow
   disabling normalization, which [`fit_gaussian()`][extra.utils.fit_gaussian] will
   use by default (!221).
+- [`fit_gaussian()`][extra.utils.fit_gaussian] has a new `Asign` parameter to
+  specify the expected orientation of the peak (!222).
 
 ## [2024.1.2]
 Added:

--- a/src/extra/utils/functions.py
+++ b/src/extra/utils/functions.py
@@ -50,8 +50,9 @@ def fit_gaussian(ydata, xdata=None, p0=None, norm=False, Asign=0, **kwargs):
         p0 (list): A list of `[y0, A, μ, σ]` to match the arguments to
             [gaussian()][extra.utils.gaussian].
         norm (bool): Whether to fit a normalized or unnormalized Gaussian.
-        Asign (int): 1 for an upwards peak, -1 for downwards. 0 (default) allows
-            either, using a faster algorithm. Passing `bounds=` overrides this.
+        Asign (int): Sign of the amplitude (A) parameter for the Gaussian.
+            1 for an upwards peak, -1 for downwards. 0 (default) allows either,
+            using a faster algorithm. Passing `bounds=` overrides this.
         **kwargs (): All other keyword arguments will be passed to
             [curve_fit()][scipy.optimize.curve_fit].
     """

--- a/src/extra/utils/functions.py
+++ b/src/extra/utils/functions.py
@@ -25,7 +25,7 @@ def gaussian(x, y0, A, μ, σ, norm=True):
     return y0 + (A / norm_factor) * np.exp(-(x - μ)**2 / (2 * σ**2))
 
 
-def fit_gaussian(ydata, xdata=None, p0=None, norm=False, **kwargs):
+def fit_gaussian(ydata, xdata=None, p0=None, norm=False, Asign=0, **kwargs):
     """Fit a Gaussian to some data.
 
     This uses [curve_fit()][scipy.optimize.curve_fit] to fit a Gaussian (from
@@ -50,6 +50,8 @@ def fit_gaussian(ydata, xdata=None, p0=None, norm=False, **kwargs):
         p0 (list): A list of `[y0, A, μ, σ]` to match the arguments to
             [gaussian()][extra.utils.gaussian].
         norm (bool): Whether to fit a normalized or unnormalized Gaussian.
+        Asign (int): 1 for an upwards peak, -1 for downwards. 0 (default) allows
+            either, using a faster algorithm. Passing `bounds=` overrides this.
         **kwargs (): All other keyword arguments will be passed to
             [curve_fit()][scipy.optimize.curve_fit].
     """
@@ -69,13 +71,26 @@ def fit_gaussian(ydata, xdata=None, p0=None, norm=False, **kwargs):
         return None
 
     if p0 is None:
-        μ_idx = np.argmax(ydata)
+        if Asign >= 0:  # Peak upwards (or not specified)
+            μ_idx = np.argmax(ydata)
+            A = max(1, ydata[μ_idx])
+            y0 = np.min(ydata)
+        else:  # Peak downwards
+            μ_idx = np.argmin(ydata)
+            A = min(-1, ydata[μ_idx])
+            y0 = np.max(ydata)
 
         μ = xdata[μ_idx]
-        A = max(1, ydata[μ_idx])
         σ = abs(np.max(xdata) - np.min(xdata)) / 4
-        y0 = np.min(ydata)
         p0 = [y0, A, μ, σ]
+
+    if Asign != 0 and 'bounds' not in kwargs:
+        Amin, Amax = (0, np.inf) if Asign > 0 else (-np.inf, 0)
+        kwargs['bounds'] = (
+            # y0      A     μ        σ
+            [-np.inf, Amin, -np.inf, 0],
+            [np.inf,  Amax, np.inf, np.inf],
+        )
 
     func = lambda *args: gaussian(*args, norm=norm)
     try:

--- a/src/extra/utils/functions.py
+++ b/src/extra/utils/functions.py
@@ -25,7 +25,7 @@ def gaussian(x, y0, A, μ, σ, norm=True):
     return y0 + (A / norm_factor) * np.exp(-(x - μ)**2 / (2 * σ**2))
 
 
-def fit_gaussian(ydata, xdata=None, p0=None, norm=False, Asign=0, **kwargs):
+def fit_gaussian(ydata, xdata=None, p0=None, norm=False, A_sign=0, **kwargs):
     """Fit a Gaussian to some data.
 
     This uses [curve_fit()][scipy.optimize.curve_fit] to fit a Gaussian (from
@@ -50,7 +50,7 @@ def fit_gaussian(ydata, xdata=None, p0=None, norm=False, Asign=0, **kwargs):
         p0 (list): A list of `[y0, A, μ, σ]` to match the arguments to
             [gaussian()][extra.utils.gaussian].
         norm (bool): Whether to fit a normalized or unnormalized Gaussian.
-        Asign (int): Sign of the amplitude (A) parameter for the Gaussian.
+        A_sign (int): Sign of the amplitude (A) parameter for the Gaussian.
             1 for an upwards peak, -1 for downwards. 0 (default) allows either,
             using a faster algorithm. Passing `bounds=` overrides this.
         **kwargs (): All other keyword arguments will be passed to
@@ -72,7 +72,7 @@ def fit_gaussian(ydata, xdata=None, p0=None, norm=False, Asign=0, **kwargs):
         return None
 
     if p0 is None:
-        if Asign >= 0:  # Peak upwards (or not specified)
+        if A_sign >= 0:  # Peak upwards (or not specified)
             μ_idx = np.argmax(ydata)
             A = max(1, ydata[μ_idx])
             y0 = np.min(ydata)
@@ -85,8 +85,8 @@ def fit_gaussian(ydata, xdata=None, p0=None, norm=False, Asign=0, **kwargs):
         σ = abs(np.max(xdata) - np.min(xdata)) / 4
         p0 = [y0, A, μ, σ]
 
-    if Asign != 0 and 'bounds' not in kwargs:
-        Amin, Amax = (0, np.inf) if Asign > 0 else (-np.inf, 0)
+    if A_sign != 0 and 'bounds' not in kwargs:
+        Amin, Amax = (0, np.inf) if A_sign > 0 else (-np.inf, 0)
         kwargs['bounds'] = (
             # y0      A     μ        σ
             [-np.inf, Amin, -np.inf, 0],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,9 +19,19 @@ def test_fit_gaussian():
     popt = fit_gaussian(data)
     assert np.allclose(popt, params)
 
+    # Test with A constrained to be >0
+    popt_A_pos = fit_gaussian(data, Asign=1)
+    assert np.allclose(popt_A_pos, params)
+
     # Test with provided xdata
     params = [0, 1, 0.5, 0.2]
     xdata = np.arange(0, 1, 0.01)
     data = gaussian(xdata, *params, norm=False)
     popt = fit_gaussian(data, xdata=xdata)
+    assert np.allclose(popt, params)
+
+    # Test with a downwards-pointing peak
+    params = [0, -3, 20, 5]
+    data = gaussian(np.arange(100), *params, norm=False)
+    popt = fit_gaussian(data, Asign=-1)
     assert np.allclose(popt, params)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,7 +20,7 @@ def test_fit_gaussian():
     assert np.allclose(popt, params)
 
     # Test with A constrained to be >0
-    popt_A_pos = fit_gaussian(data, Asign=1)
+    popt_A_pos = fit_gaussian(data, A_sign=1)
     assert np.allclose(popt_A_pos, params)
 
     # Test with provided xdata
@@ -33,5 +33,5 @@ def test_fit_gaussian():
     # Test with a downwards-pointing peak
     params = [0, -3, 20, 5]
     data = gaussian(np.arange(100), *params, norm=False)
-    popt = fit_gaussian(data, Asign=-1)
+    popt = fit_gaussian(data, A_sign=-1)
     assert np.allclose(popt, params)


### PR DESCRIPTION
Specify Asign=1 for a peak pointing upwards, or Asign=-1 for a peak pointing downwards. The default leaves it unconstrained, but the initial parameter guesses in that case are for an upwards peak, preserving the current behaviour.

Specifying bounds make `curve_fit` switch to a slower method, but how much slower seems to be very variable. In one test, I went from ~4ms per fit to ~40ms, but in another test, only from about 2.3 ms to 3.6 ms. The default still uses no bounds so it can use the faster algorithm.