### PR TITLE
Fix sign for stage-to-time conversion in OpticalLaserDelay

### DIFF
--- a/src/extra/components/las.py
+++ b/src/extra/components/las.py
@@ -273,7 +273,7 @@ class OpticalLaserDelay:
     @property
     def _stage_to_time(self) -> float:
         """millimeter to seconds"""
-        return -2e-3 / speed_of_light
+        return 2e-3 / speed_of_light
 
     @property
     def time_scale(self) -> float:


### PR DESCRIPTION
This is a bit embarassing, and I'm still puzzled how it actually came to be. I double-checked it multiple times now with different datasets and it's consistent. Note that the problem is only relevant (in the sense of giving **wrong** values) when combining trigger and stage delay, by themselves it just seems like an odd definition.

@JamesWrigley Do you know whether this was used at MID already (only other really supported instrument)? This will change the values actually, though the impact is *only* the sign if not combining with other delay sources.