### PR TITLE
Add a Timepix3 component

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -23,6 +23,7 @@ Fixed:
 
 Changed:
 
+- [Timepix3][extra.components.Timepix3] to access raw hits and centroids from the Timepix3 detector (!231).
 - [`gaussian()`][extra.utils.gaussian] has a new `norm` parameter to allow
   disabling normalization, which [`fit_gaussian()`][extra.utils.fit_gaussian] will
   use by default (!221).

--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -18,6 +18,8 @@ Component index:
     - [DldPulses][extra.components.DldPulses]
 - [Delay Line Detectors](delay-line-detectors.md)
     - [DelayLineDetector][extra.components.DelayLineDetector]
+- [Timepix](timepix.md)
+    - [Timepix3][extra.components.Timepix3]
 - [Optical Lasers](optical-lasers.md)
     - [OpticalLaserDelay][extra.components.OpticalLaserDelay]
 - [ADQ Digitizers](adq-digitizers.md)

--- a/docs/components/timepix.md
+++ b/docs/components/timepix.md
@@ -1,0 +1,1 @@
+::: extra.components.Timepix3

--- a/src/extra/components/__init__.py
+++ b/src/extra/components/__init__.py
@@ -5,6 +5,7 @@ from .pulses import XrayPulses, OpticalLaserPulses, MachinePulses, \
 from .scan import Scan  # noqa
 from .xgm import XGM  # noqa
 from .dld import DelayLineDetector  # noqa
+from .timepix import Timepix3  # noqa
 from .las import OpticalLaserDelay  # noqa
 from .adq import AdqRawChannel  # noqa
 from .detector_motors import AGIPD1MQuadrantMotors  # noqa

--- a/src/extra/components/pulses.py
+++ b/src/extra/components/pulses.py
@@ -520,7 +520,8 @@ class PulsePattern:
              DeprecationWarning, stacklevel=2)
         return self.pulse_counts(*args, **kwargs)
 
-    def build_pulse_index(self, pulse_dim='pulseId', include_extra_dims=True):
+    def build_pulse_index(self, pulse_dim='pulseId', include_extra_dims=True,
+                          pulse_dtype=None):
         """Get a multi-level index for pulse-resolved data.
 
         Args:
@@ -529,6 +530,8 @@ class PulsePattern:
             include_extra_dims (bool, optional): Whether to include any
                 additional dimensions of this particular implementation
                 beyond train ID and pulse dimension.
+            pulse_dtype (numpy.dtype, optional): If specified, force
+                casts the pulse dimension to the specified dtype.
 
         Returns:
             (pandas.MultiIndex): Multi-level index covering train ID,
@@ -559,6 +562,9 @@ class PulsePattern:
         if include_extra_dims:
             index_levels.update({name: pulse_ids.index.get_level_values(name)
                                  for name in pulse_ids.index.names[2:]})
+
+        if pulse_dtype is not None:
+            index_levels[pulse_dim] = index_levels[pulse_dim].astype(pulse_dtype)
 
         import pandas as pd
         return pd.MultiIndex.from_arrays(

--- a/src/extra/components/timepix.py
+++ b/src/extra/components/timepix.py
@@ -1,0 +1,618 @@
+
+from collections import defaultdict
+from io import IOBase
+from os import PathLike
+import re
+
+import numpy as np
+import pandas as pd
+
+from extra_data import by_id
+
+
+# Pulse indices used internally for virtual leading and trailing pulses.
+TRAILING_PULSE_INDEX = 2**31 - 1
+LEADING_PULSE_INDEX = -TRAILING_PULSE_INDEX - 1
+
+
+class Timepix3:
+    """Interface to Timepix3 event data.
+
+    Timepix3 is an event-based pixel detectors, generating a stream of
+    events of when and how long a singular pixel is detected. This
+    component gives convenient [pd.dataframe][pandas.DataFrame]-based
+    access to directly acquired raw pixel events, as well as centroided
+    events available after automatic processing. These centroids attempt
+    to group events in time and space that belong to the same particle
+    impact to a single event.
+
+    The component can be initialized with either the raw data source,
+    the virtual calibrated source containing the centroided results or
+    both. Pulse pattern information are necessary in both cases to sort
+    events into pulses, as they are originally recorded by train.
+
+    Args:
+        data (extra_data.DataCollection): Data to access Timepix3 data from.
+        detector (str, optional): Name of the detector, only
+            needed if the data includes more than one. This should
+            be the first part of the source name, i.e. up to the first
+            slash.
+        pulses (extra.components.pulses.PulsePattern, optional): Pulse
+            component to pull pulse information. If omitted, an
+            [XrayPulses][extra.components.XrayPulses] object is
+            constructed from the data.
+    """
+
+    # Only support single-chip detectors for now.
+    _instrument_re = re.compile(
+        r'^(\w{3}_\w+_TIMEPIX)\/(DET|CAL)\/\w+:daqOutput.chip0$')
+
+    def __init__(self, data, detector=None, pulses=None, **kwargs):
+        # Always run detection to potentially find the raw and
+        # centroided data sources depending on passed prefix.
+        self._detector_name, sources = self._find_detector(
+            data, detector or '')
+
+        self._raw_control_src = None
+        self._raw_instrument_src = None
+        self._centroids_control_src = None
+        self._centroids_instrument_src = None
+
+        for source in sources:
+            if '/DET/' in source:
+                self._raw_instrument_src = data[source]
+
+                if (s := source[:source.rfind(':')]) in data.control_sources:
+                    self._raw_control_src = data[s]
+            elif '/CAL/' in source:
+                self._centroids_instrument_src = data[source]
+
+                if (s := source[:source.rfind(':')]) in data.control_sources:
+                    self._centroids_control_src = data[s]
+
+        if self._raw_instrument_src is not None:
+            # For raw data, several keys must be accessed as well as
+            # potentially correlated with centroid data. For efficient
+            # access with pasha, we keep around a minimal DataCollection
+            # selected down to those trains with raw data.
+
+            selection = {self._raw_instrument_src.source: {
+                'data.x', 'data.y', 'data.toa', 'data.tot'}}
+
+            if self._centroids_instrument_src is not None:
+                selection[self._centroids_instrument_src.source] = {
+                    'data.labels'}
+
+            raw_train_ids = self.raw_size_key.drop_empty_trains().train_ids
+            self._raw_instrument_dc = data \
+                .select(selection).select_trains(by_id[raw_train_ids])
+
+        if pulses is None:
+            from . import XrayPulses
+            pulses = XrayPulses(data)
+
+        # This pulse component is not yet train-aligned, as raw and
+        # centroided data may cover different trains.
+        self._pulses = pulses
+
+    def __repr__(self):
+        data_labels = []
+
+        if self._raw_instrument_src is not None:
+            data_labels.append('raw')
+
+        if self._centroids_instrument_src is not None:
+            data_labels.append('centroids')
+
+        return "<{} {}: {}>".format(type(self).__name__, self._detector_name,
+                                    ', '.join(data_labels))
+
+    @staticmethod
+    def _prepare_pasha(parallel):
+        """Prepare pasha context."""
+
+        import pasha
+
+        if parallel is True:
+            # Catch True explicitly to not cause an int cast to 1 and
+            # disabling below.
+            parallel = None
+
+        if parallel is not None and int(parallel) < 2:
+            return pasha.SerialContext()
+        else:
+            return pasha.ProcessContext(parallel)
+
+    @classmethod
+    def _find_detector(cls, data, domain=''):
+        """Try to find detector source."""
+
+        detectors = defaultdict(list)
+
+        for source in data.instrument_sources:
+            m = cls._instrument_re.match(source)
+            if m is not None and (not domain or m[1] == domain):
+                detectors[m[1]].append(source)
+
+        if len(detectors) > 1:
+            raise ValueError('multiple detectors found, please pass one '
+                             'explicitly:\n' + ', '.join(sorted(detectors)))
+        elif detectors:
+            return next(iter(detectors.items()))
+
+        if domain:
+            raise ValueError(f'no sources found for detector {domain}')
+        else:
+            raise ValueError('no detector found, please pass one explicitly')
+
+    @staticmethod
+    def _sort_timepix_data(train_id, pids, toa_offset, rep_rate, timewalk_lut,
+                           toa_in, tot_in, toa, tof, pulse_indices, pos):
+        """Sort Timepix data and bin into pulses."""
+
+        # Convert input ToA to μs and apply custom offset.
+        toa_in *= 1e6
+        toa_in -= toa_offset
+
+        # Sort input ToA and load into output.
+        pos[:] = np.argsort(toa_in)
+        toa[:] = toa_in[pos]
+
+        # Apply raw timewalk correction if applicable.
+        if timewalk_lut is not None:
+            toa -= timewalk_lut[(tot_in[pos] // 25) - 1] * 1e6
+
+        # Determine pulse boundaries.
+        try:
+            train_pids = pids.loc[train_id].to_numpy()
+        except KeyError:
+            # No pulses present in this train, move all rows to trailing.
+            pulse_starts = np.array([-1])
+            last_pulse_end = -1
+        else:
+            # Start time of all pulses.
+            pulse_starts = (train_pids - train_pids[0]) / rep_rate
+
+            # End time of the last pulse.
+            if len(pulse_starts) > 1:
+                # Add the largest pulse difference to the last start.
+                last_pulse_end = pulse_starts[-1] + np.diff(pulse_starts).max()
+            else:
+                # Take largest ToA as pulse end if there is only a
+                # single pulse in the train.
+                last_pulse_end = toa.max()
+
+        # Sort ToA into pulse bins, except for the last pulse.
+        indices = pd.cut(pd.Series(toa), pulse_starts, labels=False,
+                         include_lowest=True)
+
+        # Any negative ToA is before the first pulse, assign temporarily
+        # to the first pulse for ToF computation below as it uses the
+        # same offset.
+        indices[toa < 0.0] = 0.0
+
+        # Assign magic pulse index to rows are after the last pulse.
+        indices[toa > last_pulse_end] = TRAILING_PULSE_INDEX
+
+        # Anything still NaN is IN the last pulse, as pd.cut above only
+        # covered pulse beginnings.
+        indices.fillna(len(pulse_starts) - 1, inplace=True)
+
+        # Assign result to output (may cause an int cast) and generate
+        # mask for pulses we can offset with pulse_starts above, i.e.
+        # the actual pulses and virtual leading pulse and not the
+        # virtual trailing pulse).
+        pulse_indices[:] = indices
+        mask = pulse_indices < TRAILING_PULSE_INDEX
+
+        # Subtract pulse starts for ToF of non-trailing hits, and
+        # subtract the last pulse's end from trailing hits.
+        tof[:] = toa
+        tof[mask] -= pulse_starts[pulse_indices[mask]]
+        tof[~mask] -= last_pulse_end
+
+        # Finally correct virtual leading pulse, those with negative
+        # ToA/ToF, to their own magic pulse index.
+        pulse_indices[toa < 0.0] = LEADING_PULSE_INDEX
+
+        return pos
+
+    @staticmethod
+    def _build_pulse_index(train_ids, pulses, pulse_dim, rows_per_train,
+                           row_pidx, out_of_pulse_events):
+        """Build pulse index aligned to Timepix hits or centroids."""
+
+        # Determine additional pulse indices and values required for
+        # leading and trailing hits, i.e. before and after "pulses", or
+        # create a mask to exclude them.
+        # The indices are used internally and denote those cases with
+        # -1 and INT32_MAX, respectively. The returned index however
+        # is forced to float using -np.inf and +np.inf.
+        # If either virtual pulses are disabled, they are masked out.
+        if out_of_pulse_events:
+            mask = np.s_[:]
+            extra_pulse_idx = [LEADING_PULSE_INDEX, TRAILING_PULSE_INDEX]
+            extra_pulse_vals = [-np.inf, +np.inf]
+        else:
+            mask = (row_pidx != LEADING_PULSE_INDEX) & \
+                (row_pidx != TRAILING_PULSE_INDEX)
+            extra_pulse_idx = []
+            extra_pulse_vals = []
+
+        # Build the initial pulse index with the pulse pattern
+        # component, which is by-pulse. If either virtual pulses are
+        # enabled, force the pulse dimension to be float to account for
+        # its special values.
+        pulse_index = pulses.build_pulse_index(
+            pulse_dim, pulse_dtype=np.float64 if extra_pulse_vals else None)
+
+        if extra_pulse_vals:
+            # For now, only the generic pulse pattern and their custom
+            # fields are supported. When needed, add default values for
+            # the leading/trailing pseudo-pulses.
+            if set(pulse_index.names[2:]) - {'fel', 'ppl'}:
+                raise ValueError('custom pulse index labels are not supported '
+                                 'when including out of pulse events')
+
+            custom_pulse_vals = []
+            if 'fel' in pulse_index.names:
+                custom_pulse_vals.append([False])
+
+            if 'ppl' in pulse_index.names:
+                custom_pulse_vals.append([False])
+
+            orig_names = pulse_index.names
+            pulse_index = pulse_index.append(pd.MultiIndex.from_product(
+                [train_ids, extra_pulse_vals, *custom_pulse_vals]
+            )).sort_values()
+            pulse_index.names = orig_names  # Restore names after append.
+
+        # Count the number of hits per train and pulse that actually
+        # occured - this may be missing trains and pulses without any
+        # hits.
+        actual_rows_per_pulse = pd.DataFrame(data={
+            'trainId': np.repeat(train_ids, rows_per_train)[mask],
+            'pulseIndex': row_pidx[mask]
+        }).groupby(['trainId', 'pulseIndex']).size()
+
+        # Build an index for each possibly occuring train and pulse.
+        # Beginning from the pulse ID index from the pulse pattern
+        # component, drop any custom levels, append the extra values for
+        # leading/trailing pulses above and sort again.
+        pulse_ids = pulses.pulse_ids()
+        counts_index = pulse_ids.index \
+            .droplevel(list(range(2, pulse_ids.index.nlevels))) \
+            .append(pd.MultiIndex.from_product([train_ids, extra_pulse_idx])) \
+            .sort_values()
+
+        # Use the data frame with train/pulse data from above to count
+        # hits by pulse for any possibly occuring pulse - this is
+        # important as there may be pulses in the pulse index without
+        # any hits!
+        rows_per_pulse = pd.Series(np.zeros(len(counts_index), dtype=int),
+                                   index=counts_index)
+        rows_per_pulse[actual_rows_per_pulse.index] = actual_rows_per_pulse
+
+        # Repeat the initial data index (which is by pulse) accordingly
+        # for each hit, and add in a new level for a hit index.
+        index_df = pulse_index.repeat(rows_per_pulse).to_frame(index=False)
+
+        return pd.MultiIndex.from_frame(index_df), mask
+
+    @property
+    def detector_name(self):
+        return self._detector_name
+
+    @property
+    def raw_control_src(self):
+        if self._raw_control_src is None:
+            raise ValueError('raw control data is not available as component '
+                             'was initialized with data not containing it')
+
+        return self._raw_control_src
+
+    @property
+    def raw_instrument_src(self):
+        if self._raw_instrument_src is None:
+            raise ValueError('raw pixel events are not available as component '
+                             'was initialized with data not containing it')
+
+        return self._raw_instrument_src
+
+    @property
+    def raw_x_key(self):
+        return self.raw_instrument_src['data.x']
+
+    @property
+    def raw_y_key(self):
+        return self.raw_instrument_src['data.y']
+
+    @property
+    def raw_toa_key(self):
+        return self.raw_instrument_src['data.toa']
+
+    @property
+    def raw_tot_key(self):
+        return self.raw_instrument_src['data.tot']
+
+    @property
+    def raw_size_key(self):
+        return self.raw_instrument_src['data.size']
+
+    @property
+    def centroids_control_src(self):
+        if self._centroids_control_src is None:
+            raise ValueError('centroid control data is not available as '
+                             'component was initialized with data not '
+                             'containing it')
+
+        return self._centroids_control_src
+
+    @property
+    def centroids_instrument_src(self):
+        if self._centroids_instrument_src is None:
+            raise ValueError('centroids are not available as component was '
+                             'initialized with data not containing it')
+
+        return self._centroids_instrument_src
+
+    @property
+    def centroids_key(self):
+        return self.centroids_instrument_src['data.centroids']
+
+    @property
+    def centroid_labels_key(self):
+        return self.centroids_instrument_src['data.labels']
+
+    def spatial_bins(self, min_pos=0, max_pos=256, bins_per_px=1):
+        """Build suitable bin edges for Timepix position data.
+
+        The bins are centered around integer pixel position to avoid
+        binning artifacts.
+
+        Args:
+            min_pos (int, optional): Lower spatial boundary,
+                0 by default.
+            max_pos (int, optional): Upper spatial boundary,
+                256 by default.
+            bins_per_px (int, optional): Number of bins per pixel,
+                1 by default
+
+        Returns:
+            bins (numpy.ndarray) Spatial bin edges.
+        """
+
+        return np.arange(min_pos, max_pos, 1/bins_per_px) - 0.5/bins_per_px
+
+    def pixel_events(self, pulse_dim='pulseId', toa_offset=0.0,
+                     timewalk_lut=None, out_of_pulse_events=False,
+                     extended_columns=False, parallel=None):
+        """Get raw pixel events as dataframe.
+
+        Loads the original raw pixel events as a dataframe and sorts
+        them into pulses using the initialized pulse pattern component.
+
+        By default, only events the pulse windows are included. The
+        `out_of_pulse_events` arguments allows to extend this to events
+        before the first and after the last pulse.
+
+        An event is considered part of a particular pulse when its
+        time-of-arrival is between the beginning of that and the next
+        pulse For the last pulse, the single largest spacing between
+        pulses is chosen while in case of a single pulse in the entire
+        train, all pulses will be assigned to it. The `toa_offset`
+        argument denotes the time-of-arrival at the start of the first
+        pulse of the train.
+
+        Args:
+            pulse_dim ('pulseId' or 'pulseIndex' or 'pulseTime', optional):
+                Which pulse coordinates to use in the index, pulse ID by
+                default.
+            toa_offset (float, optional): Time-of-arrival offset applied
+                by train in microseconds, 0.0 by default.
+            timewalk_lut (numpy.typing.ArrayLike or os.PathLike or None,
+                optional): Timewalk LUT to correct ToA or path to a file
+                compatible with np.load, none by default.
+            out_of_pulse_events (bool, optional): Whether to include
+                hits before the first pulse and after the last pulse in
+                virtual pulses labelled -np.inf and np.inf, False by
+                default. If enabled, the pulse index dimension will be
+                forced to float.
+            extended_columns (bool, optional): Whether to include the
+                original time-of-arrival, readout position and centroid
+                labels for each pixel event, False by default. Labels
+                require centroiding data to be present.
+            parallel (int or None, optional): Nunmber of parallel
+                processes to use, by default 10 or a quarter of all cores
+                whichever is lower. Any non-positive value or 1 disable
+                parallelization.
+
+        Returns:
+            hits (pandas.DataFrame): Raw detector hits.
+        """
+
+        # Prepare aligned data sources.
+        tids = self._raw_instrument_dc.train_ids
+        pulses = self._pulses.select_trains(by_id[tids])
+        pids = pulses.pulse_ids()
+        machine_rep_rate = pulses.bunch_repetition_rate * 1e-6
+
+        # Obtain hits per train and compute total number of hits.
+        hits_per_train = self.raw_size_key.ndarray()
+        num_hits = int(hits_per_train.sum())
+
+        # Offset of each train in the by-hit buffers below.
+        hit_train_offsets = np.zeros_like(hits_per_train)
+        hit_train_offsets[1:] = np.cumsum(hits_per_train[:-1])
+
+        # Buffers by hit for X, Y, ToA, ToF, ToT, pulse index, (original)
+        # position and optionally centroid labels.
+        psh = self._prepare_pasha(parallel)
+        hits_x = psh.alloc(shape=num_hits, dtype=self.raw_x_key.dtype)
+        hits_y = psh.alloc(shape=num_hits, dtype=self.raw_y_key.dtype)
+        hits_toa = psh.alloc(shape=num_hits, dtype=self.raw_toa_key.dtype)
+        hits_tof = psh.alloc(shape=num_hits, dtype=self.raw_toa_key.dtype)
+        hits_tot = psh.alloc(shape=num_hits, dtype=self.raw_tot_key.dtype)
+        hits_pidx = psh.alloc(shape=num_hits, dtype=np.int32)
+        hits_pos = psh.alloc(shape=num_hits, dtype=np.int32)
+
+        if extended_columns and self._centroids_instrument_src is not None:
+            hits_label = psh.alloc(shape=num_hits, dtype=np.int32)
+        else:
+            hits_label = None
+
+        if isinstance(timewalk_lut, (str, PathLike, IOBase)):
+            timewalk_lut = np.load(timewalk_lut)
+
+        def load_tpx_raw(wid, index, train_id, data):
+            raw = data[self._raw_instrument_src.source]
+
+            count = hits_per_train[index]
+
+            if count == 0:
+                return
+
+            offset = hit_train_offsets[index]
+            dest_slice = np.s_[offset:offset+count]
+
+            sorted_idx = self._sort_timepix_data(
+                train_id, pids, toa_offset, machine_rep_rate, timewalk_lut,
+                raw['data.toa'][:count], raw['data.tot'][:count],
+                hits_toa[dest_slice], hits_tof[dest_slice],
+                hits_pidx[dest_slice], hits_pos[dest_slice])
+
+            hits_x[dest_slice] = raw['data.x'][sorted_idx]
+            hits_y[dest_slice] = raw['data.y'][sorted_idx]
+            hits_tot[dest_slice] = raw['data.tot'][sorted_idx]
+
+            if hits_label is not None:
+                centroids = data[self._centroids_instrument_src.source]
+                hits_label[dest_slice] = centroids['data.labels'][sorted_idx]
+
+        # Load data and bin hits into pulses.
+        psh.map(load_tpx_raw, self._raw_instrument_dc)
+
+        # Build a properly aligned pulse index.
+        index, mask = self._build_pulse_index(
+            tids, pulses, pulse_dim, hits_per_train,
+            hits_pidx, out_of_pulse_events)
+
+        # Build the data frame with detector data and the prepared index.
+        frame_data = {'x': hits_x[mask], 'y': hits_y[mask],
+                      't': hits_tof[mask], 'tot': hits_tot[mask]}
+
+        if extended_columns:
+            frame_data['toa'] = hits_toa[mask]
+            frame_data['pos'] = hits_pos[mask]
+
+            if hits_label is not None:
+                frame_data['label'] = hits_label[mask]
+
+        df = pd.DataFrame(data=frame_data, index=index)
+
+        return df
+
+    def centroid_events(self, pulse_dim='pulseId', toa_offset=0.0,
+                        out_of_pulse_events=False, extended_columns=False,
+                        parallel=None):
+        """Get centroided events as dataframe.
+
+        Loads the processed centroided pixel events as a dataframe and
+        sorts them into pulses using the initialized pulse pattern
+        component. The arguments and behaviour are analogous to
+        [pixel_events()][extra.components.Timepix3.pixel_events].
+
+        Args:
+            pulse_dim ('pulseId' or 'pulseIndex' or 'pulseTime', optional):
+                Which pulse coordinates to use in the index, pulse ID by
+                default.
+            toa_offset (float, optional): Time-of-arrival offset applied
+                by train in microseconds, 0.0 by default.
+            out_of_pulse_events (bool, optional): Whether to include
+                centroids before the first pulse and after the last
+                pulse in virtual pulses labelled -np.inf and np.inf,
+                False by default. If enabled, the pulse index dimension
+                will be forced to float.
+            extended_columns (bool, optional): Whether to include the
+                original average and maximal time-over-threshold,
+                size and label for each centroid, False by default.
+            parallel (int or None, optional): Nunmber of parallel
+                processes to use, by default 10 or a quarter of all cores
+                whichever is lower. Any non-positive value or 1 disable
+                parallelization.
+
+        Returns:
+            centroids (pandas.DataFrame): Centroids.
+        """
+
+        # Prepare aligned data sources.
+        kd = self.centroids_key.drop_empty_trains()
+        tids = kd.train_ids
+        pulses = self._pulses.select_trains(by_id[tids])
+        pids = pulses.pulse_ids()
+        machine_rep_rate = pulses.bunch_repetition_rate * 1e-6
+
+        # Centroids (unfortunately) do not have a size key, so load
+        # all of them into memory to obtain the centroid per train
+        # from the data via finite checks
+        centroids = kd.ndarray()
+
+        # Obtain centroid per train and compute total number of centroids.
+        rows_per_train = centroids.shape[1]
+        centroids_per_train = np.isfinite(centroids['x']).sum(axis=1)
+        num_centroids = int(centroids_per_train.sum())
+
+        # Offset of each train in the by-centroid buffers below.
+        centroids_train_offsets = np.zeros_like(centroids_per_train)
+        centroids_train_offsets[1:] = np.cumsum(centroids_per_train[:-1])
+
+        # Buffers by centroid for pulse index, row (index) and label.
+        psh = self._prepare_pasha(parallel)
+        centroids_toa = psh.alloc(
+            shape=num_centroids, dtype=self.centroids_key.dtype['toa'])
+        centroids_tof = psh.alloc(
+            shape=num_centroids, dtype=self.centroids_key.dtype['toa'])
+        centroids_pidx = psh.alloc(shape=num_centroids, dtype=np.int32)
+        centroids_rows = psh.alloc(shape=num_centroids, dtype=np.int32)
+        centroids_label = psh.alloc(shape=num_centroids, dtype=np.int32)
+
+        def process_tpx_centroids(wid, index, centroids):
+            count = centroids_per_train[index]
+
+            if count == 0:
+                return
+
+            offset = centroids_train_offsets[index]
+            dest_slice = np.s_[offset:offset+count]
+
+            sorted_idx = self._sort_timepix_data(
+                tids[index], pids, toa_offset, machine_rep_rate, None,
+                centroids['toa'][:count], None,  # ToT not required
+                centroids_toa[dest_slice], centroids_tof[dest_slice],
+                centroids_pidx[dest_slice], centroids_label[dest_slice])
+
+            centroids_rows[dest_slice] = index * rows_per_train + sorted_idx
+
+        # Process centroids to sort by ToA and bin into pulses.
+        psh.map(process_tpx_centroids, centroids)
+
+        # Build a properly aligned pulse index.
+        index, mask = self._build_pulse_index(
+            tids, pulses, pulse_dim, centroids_per_train,
+            centroids_pidx, out_of_pulse_events)
+
+        # Build the data frame with centroids and the prepared index.
+        df = pd.DataFrame.from_records(
+            centroids.ravel()[centroids_rows][mask], index=index,
+            exclude=(['size', 'tot_avg', 'tot_max', 'toa']
+                     if not extended_columns else []))
+        df.insert(2, 't', centroids_tof[mask])
+
+        if extended_columns:
+            df.rename(columns={'size': 'centroid_size'}, inplace=True)
+            df['toa'] = centroids_toa[mask]  # Overwrite with modified data.
+            df.insert(6, 'toa', df.pop('toa'))  # Re-order ToA
+            df.insert(3, 'tot', df.pop('tot'))  # Re-order ToT.
+            df['label'] = centroids_label[mask]
+
+        return df

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ from extra_data.tests.mockdata.motor import Motor
 from .mockdata.detector_motors import (
     DetectorMotorDataSelector, get_motor_sources, write_motor_positions)
 from .mockdata.dld import ReconstructedDld
+from .mockdata.timepix import Timepix3Receiver, Timepix3Centroids
 from .mockdata.timeserver import PulsePatternDecoder, Timeserver
 from .mockdata.xgm import XGM, XGMD, XGMReduced
 
@@ -108,3 +109,21 @@ def mock_sqs_remi_directory():
 @pytest.fixture(scope='function')
 def mock_sqs_remi_run(mock_sqs_remi_directory):
     yield RunDirectory(mock_sqs_remi_directory)
+
+
+@pytest.fixture(scope='session')
+def mock_sqs_timepix_directory():
+    sources = [
+        Timeserver('SQS_RR_UTC/TSYS/TIMESERVER'),
+        Timepix3Receiver('SQS_EXTRA_TIMEPIX/DET/TIMEPIX3'),
+        Timepix3Receiver('SQS_EXP_TIMEPIX/DET/TIMEPIX3'),
+        Timepix3Centroids('SQS_EXP_TIMEPIX/CAL/TIMEPIX3')]
+
+    with TemporaryDirectory() as td:
+        write_file(Path(td) / 'RAW-R0001-DA01-S00000.h5', sources, 100)
+        yield td
+
+
+@pytest.fixture(scope='function')
+def mock_sqs_timepix_run(mock_sqs_timepix_directory):
+    yield RunDirectory(mock_sqs_timepix_directory)

--- a/tests/mockdata/timepix.py
+++ b/tests/mockdata/timepix.py
@@ -1,0 +1,102 @@
+
+from extra_data.tests.mockdata.base import DeviceBase
+
+import numpy as np
+
+
+pixel_shape = (1000,)
+centroid_shape = (1000,)
+
+centroid_dt = np.dtype([('x', np.float64),
+                        ('y', np.float64),
+                        ('toa', np.float64),
+                        ('tot', np.float64),
+                        ('tot_avg', np.float64),
+                        ('tot_max', np.uint16),
+                        ('size', np.int16)])
+
+stat_dt = np.dtype([('N_centroids', np.int64),
+                    ('missing_centroids', np.bool_),
+                    ('fraction_px_in_centroids', np.float64)])
+
+
+
+class TimepixCommon(DeviceBase):
+    def _fill_hit_data(self, dset, min_val, max_val):
+        val = np.nan if np.issubdtype(dset.dtype, np.floating) else 1
+        dset[:self.ntrains] = np.stack([
+            np.concatenate([
+                np.linspace(min_val, max_val, min(N, pixel_shape[0]),
+                            dtype=dset.dtype),
+                np.full(max(pixel_shape[0] - N, 0), val, dtype=dset.dtype)
+            ])
+            for N in range(self.ntrains)])
+
+
+class Timepix3Receiver(TimepixCommon):
+    control_keys = [
+        ('biasVoltage', 'f8', ()),
+        ('chip0.ibiasIkrum', 'u1', ())
+    ]
+
+    output_channels = ('daqOutput.chip0/data',)
+
+    instrument_keys = {
+        ('x', 'u1', pixel_shape),
+        ('y', 'u1', pixel_shape),
+        ('toa', 'f8', pixel_shape),
+        ('tot', 'u2', pixel_shape),
+        ('size', 'u4', ())
+    }
+
+    extra_run_values = [
+        ('classId', None, 'Timepix3SingleReceiver')
+    ]
+
+    def write_instrument(self, f):
+        super().write_instrument(f)
+
+        root = f[f'INSTRUMENT/{self.device_id}:daqOutput.chip0/data']
+        self._fill_hit_data(root['x'], 0, 256)
+        self._fill_hit_data(root['y'], 256, 0)
+        self._fill_hit_data(root['toa'], 0.0, 5.0e-6)
+        self._fill_hit_data(root['tot'], 200, 800)
+
+        if self.ntrains > pixel_shape[0]:
+            size = np.clip(np.arange(self.ntrains), 0, pixel_shape[0])
+        else:
+            size = np.arange(self.ntrains)
+
+        root['size'][:self.ntrains] = size
+
+
+class Timepix3Centroids(TimepixCommon):
+    control_keys = [
+        ('fakeScalar', 'u4', ()),
+    ]
+
+    output_channels = ('daqOutput.chip0/data',)
+
+    instrument_keys = {
+        ('centroids', centroid_dt, centroid_shape),
+        ('labels', 'i4', pixel_shape),
+        ('stats', stat_dt, centroid_shape)
+    }
+
+    def write_instrument(self, f):
+        super().write_instrument(f)
+
+        root = f[f'INSTRUMENT/{self.device_id}:daqOutput.chip0/data']
+
+        centroids = np.zeros((self.ntrains,) + centroid_shape,
+                              dtype=centroid_dt)
+        self._fill_hit_data(centroids['x'], 0, 256)
+        self._fill_hit_data(centroids['y'], 256, 0)
+        self._fill_hit_data(centroids['toa'], 0.0, 5.0e-6)
+        self._fill_hit_data(centroids['tot'], 200, 800)
+        self._fill_hit_data(centroids['tot_avg'], 100, 400)
+        self._fill_hit_data(centroids['tot_max'], 150, 600)
+        self._fill_hit_data(centroids['size'], 1, 10)
+        root['centroids'][:self.ntrains] = centroids
+
+        self._fill_hit_data(root['labels'], 1, 10)

--- a/tests/test_components_pulses.py
+++ b/tests/test_components_pulses.py
@@ -383,6 +383,11 @@ def test_build_pulse_index(mock_spb_aux_run, source):
     with pytest.warns():
         assert pulses.get_pulse_index().equals(pulses.build_pulse_index())
 
+    # Force dtype.
+    assert pulses.build_pulse_index(
+        'pulseIndex', pulse_dtype=np.float32
+    ).dtypes['pulseIndex'] == np.float32
+
 
 @pytest.mark.parametrize('source', **pattern_sources)
 def test_search_pulse_patterns(mock_spb_aux_run, source):

--- a/tests/test_components_timepix.py
+++ b/tests/test_components_timepix.py
@@ -1,0 +1,183 @@
+
+from io import BytesIO
+
+import pytest
+import numpy as np
+import pandas as pd
+
+from extra.components import Timepix3, XrayPulses, PumpProbePulses
+from .mockdata import assert_equal_sourcedata, assert_equal_keydata
+
+
+def test_timepix3_init(mock_sqs_timepix_run):
+    run = mock_sqs_timepix_run.deselect('SQS_EXTRA*')
+
+    tpx = Timepix3(run)
+    assert tpx.detector_name == 'SQS_EXP_TIMEPIX'
+    assert_equal_sourcedata(
+        tpx.raw_control_src,
+        run['SQS_EXP_TIMEPIX/DET/TIMEPIX3'])
+    assert_equal_sourcedata(
+        tpx.raw_instrument_src,
+        run['SQS_EXP_TIMEPIX/DET/TIMEPIX3:daqOutput.chip0'])
+    assert_equal_keydata(
+        tpx.raw_x_key,
+        run['SQS_EXP_TIMEPIX/DET/TIMEPIX3:daqOutput.chip0', 'data.x'])
+    assert_equal_sourcedata(
+        tpx.centroids_control_src,
+        run['SQS_EXP_TIMEPIX/CAL/TIMEPIX3'])
+    assert_equal_sourcedata(
+        tpx.centroids_instrument_src,
+        run['SQS_EXP_TIMEPIX/CAL/TIMEPIX3:daqOutput.chip0'])
+    assert 'SQS_EXP_TIMEPIX' in repr(tpx)
+    assert 'raw, centroids' in repr(tpx)
+
+    # Whole run contains more than one detector.
+    with pytest.raises(ValueError):
+        tpx = Timepix3(mock_sqs_timepix_run)
+
+    # But works with explicit naming
+    tpx = Timepix3(mock_sqs_timepix_run, 'SQS_EXP_TIMEPIX')
+    assert_equal_sourcedata(
+        tpx.raw_control_src,
+        mock_sqs_timepix_run['SQS_EXP_TIMEPIX/DET/TIMEPIX3'])
+
+    # Also for the other detector with caveats.
+    tpx = Timepix3(mock_sqs_timepix_run, 'SQS_EXTRA_TIMEPIX')
+    assert_equal_sourcedata(
+        tpx.raw_control_src,
+        mock_sqs_timepix_run['SQS_EXTRA_TIMEPIX/DET/TIMEPIX3'])
+    assert_equal_sourcedata(
+        tpx.raw_instrument_src,
+        mock_sqs_timepix_run['SQS_EXTRA_TIMEPIX/DET/TIMEPIX3:daqOutput.chip0'])
+
+    with pytest.raises(ValueError):
+        tpx.centroids_control_src
+
+    with pytest.raises(ValueError):
+        tpx.centroids_instrument_src
+
+
+@pytest.mark.parametrize('method', ['pixel_events', 'centroid_events'])
+def test_timepix3_data(mock_sqs_timepix_run, method):
+    run = mock_sqs_timepix_run.deselect('SQS_EXTRA*')
+
+    # Default initialization will use SA3 with a single pulse.
+    tpx = Timepix3(run)
+    data = getattr(tpx, method)()
+
+    np.testing.assert_array_equal(data.columns, ['x', 'y', 't', 'tot'])
+    assert data.index.names == ['trainId', 'pulseId']
+
+    np.testing.assert_equal(
+        data.index.get_level_values('trainId').value_counts().sort_index(),
+        np.arange(10, 100))
+    assert (data.index.get_level_values('pulseId') == 200).all()
+
+    for _, d in data.groupby(['trainId', 'pulseId']):
+        N = len(d)
+        np.testing.assert_equal(
+            d['x'], np.linspace(0, 256, N, dtype=data.dtypes['x']))
+        np.testing.assert_equal(
+            d['y'], np.linspace(256, 0, N, dtype=data.dtypes['y']))
+        np.testing.assert_allclose(d['t'], np.linspace(0.0, 5.0, N))
+        np.testing.assert_equal(
+            d['tot'], np.linspace(200, 800, N, dtype=data.dtypes['tot']))
+
+    # Try without parallelization once.
+    pd.testing.assert_frame_equal(data, getattr(tpx, method)(parallel=False))
+
+    # Try different pulse dimension.
+    assert getattr(tpx, method)(
+        pulse_dim='pulseIndex').index.names[1] == 'pulseIndex'
+
+    # Apply time-of-arrival offset.
+    data = getattr(tpx, method)(toa_offset=-1.0)
+    for _, d in data.groupby(['trainId', 'pulseId']):
+        np.testing.assert_allclose(d['t'], np.linspace(1.0, 6.0, len(d)))
+
+    # Initialize for SA1 for hits across multiple pulses and with
+    # extended columns.
+    tpx = Timepix3(run, pulses=XrayPulses(run, sase=1))
+    data = getattr(tpx, method)(extended_columns=True)
+
+    np.testing.assert_equal(
+        data.index.get_level_values('trainId').value_counts().sort_index(),
+        np.arange(10, 100))
+    np.testing.assert_equal(
+        data.index.get_level_values('pulseId').value_counts().sort_index(),
+        np.array([2302, 303, 2048, 252]))
+
+    for _, pulse_data in data.groupby(['trainId', 'pulseId']):
+        # Ensure the difference ToA and ToF is always constant.
+        diff = pulse_data['t'] - pulse_data['toa']
+        assert (diff == diff.min()).all()
+
+    # Obtain SA1 data with leading/trailing virtual pulses, offset ToA
+    # to get a leading pulse.
+    data = getattr(tpx, method)(toa_offset=0.5, out_of_pulse_events=True)
+
+    np.testing.assert_equal(
+        data.index.get_level_values('trainId').value_counts().sort_index(),
+        np.arange(1, 100))  # Now includes empty trains!
+
+    pulse_dist = data.index.get_level_values('pulseId') \
+        .value_counts().sort_index()
+    np.testing.assert_allclose(
+        pulse_dist.index, [-np.inf, 1000.0, 1006.0, 1012.0, 1018.0, np.inf])
+    np.testing.assert_equal(
+        pulse_dist, np.array([531, 2262, 304, 1681, 136, 36]))
+
+    # Try with PumpProbePulses.
+    tpx = Timepix3(run, pulses=PumpProbePulses(
+        run, instrument=(1, 1024), bunch_table_position=1000))
+    data = getattr(tpx, method)(out_of_pulse_events=True)
+    assert data.index.names == ['trainId', 'pulseId', 'fel', 'ppl']
+
+
+def test_timepix3_pixel_events(mock_sqs_timepix_run):
+    tpx = Timepix3(mock_sqs_timepix_run.deselect('SQS_EXTRA*'))
+
+    # Extended columns.
+    events = tpx.pixel_events(extended_columns=True)
+
+    np.testing.assert_array_equal(
+        events.columns, ['x', 'y', 't', 'tot', 'toa', 'pos', 'label'])
+    np.testing.assert_equal(events.loc[10010]['label'], np.arange(1, 11))
+    for _, d in events.groupby(['trainId', 'pulseId']):
+        N = len(d)
+        np.testing.assert_allclose(d['toa'], np.linspace(0.0, 5.0, N))
+        np.testing.assert_array_equal(d['pos'], np.arange(N))
+        assert d['label'].iloc[0] == 1 and d['label'].iloc[-1] == 10
+
+    orig_toa = events['toa'].copy()  # For test below.
+
+    # Timewalk LUT, apply negative-only to not shift hits before the
+    # first pulse for easier comparison.
+    walk = -2e-9 * np.arange(1000)
+
+    np.save(lut_buf := BytesIO(), walk)
+    events = tpx.pixel_events(timewalk_lut=BytesIO(lut_buf.getbuffer()),
+                              extended_columns=True)
+    np.testing.assert_allclose(orig_toa.to_numpy() - events['toa'].to_numpy(),
+                               walk[(events['tot'] // 25) - 1] * 1e6)
+
+
+def test_timepix3_centroid_events(mock_sqs_timepix_run):
+    tpx = Timepix3(mock_sqs_timepix_run.deselect('SQS_EXTRA*'))
+
+    # Extended columns.
+    centroids = tpx.centroid_events(extended_columns=True)
+
+    np.testing.assert_array_equal(
+        centroids.columns, ['x', 'y', 't', 'tot', 'tot_avg', 'tot_max', 'toa',
+                            'centroid_size', 'label'])
+
+    for _, d in centroids.groupby(['trainId', 'pulseId']):
+        N = len(d)
+        np.testing.assert_allclose(d['tot_avg'], np.linspace(100, 400, N))
+        np.testing.assert_array_equal(
+            d['tot_max'], np.linspace(150, 600, N, dtype=np.uint16))
+        np.testing.assert_array_equal(
+            d['centroid_size'], np.linspace(1, 10, N, dtype=np.int16))
+        np.testing.assert_array_equal(d['label'], np.arange(N))


### PR DESCRIPTION
Timepix3 is a detector used at SQS. While having individual pixels, it is not a frame-based detector, but instead records beginning and the duration of time whenever a pixel is above some defined intensity threshold. Conceptually, it is therefore more similar to a DLD. While it has significantly worse time and spatial resolution than a DLD, it does not suffer from its multi-hit problems - every pixel is independent and it can therefore better cope with lots of signal in very short period of time across the detector.

Raw data is saved as X, Y, ToA (time-of-arrival) and ToT (time-over-threshold) per train. Offline calibration contains a correction step called centroiding, where multiple pixels are combined in space and time to a single detector event called centroid. The resulting data is saved in a similar format, but as structured arrays rather than individual keys.

This component allows to efficiently load both raw and centroid dato into pandas dataframe, similar to the DLD component. The most important step it provides is correlating the detector hits or centroids to EuXFEL pulses via ToA, with the pulse information taken from an EXtra pulse pattern component. Special modes exist to also include detector events occuring outside of pulses.

@bj-s 