### PR TITLE
Actually use title/xlabel/ylabel in Scan.plot_bin_by_steps()

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,9 @@ Fixed:
 
 - Karabacon 3.0.10 is now supported by the [Scantool][extra.components.Scantool]
   (!212).
+- [`Scan.plot_bin_by_steps()`][extra.components.Scan.plot_bin_by_steps] would
+  previously ignore the `title`/`xlabel`/`ylabel` arguments, now it actually
+  uses them (!237).
 
 Changed:
 

--- a/src/extra/components/scan.py
+++ b/src/extra/components/scan.py
@@ -289,17 +289,18 @@ class Scan:
                         binned_data + binned_data.uncertainty,
                         alpha=0.5)
         ax.grid()
-        ax.set_xlabel(self.name)
+        ax.set_xlabel(self.name if xlabel is None else xlabel)
+
 
         if binned_data.name is not None:
-            ax.set_ylabel(binned_data.name)
+            ax.set_ylabel(binned_data.name if ylabel is None else ylabel)
             yaxis = binned_data.name
         else:
-            ax.set_ylabel("Signal [arb. u.]")
+            ax.set_ylabel("Signal [arb. u.]" if ylabel is None else ylabel)
             yaxis = "Signal"
 
         ax.legend()
-        ax.set_title(f"{yaxis} vs {self.name}")
+        ax.set_title(f"{yaxis} vs {self.name}" if title is None else title)
 
         return ax
 


### PR DESCRIPTION
Rather embarrassingly these arguments were completely ignored.

This would be rather useful now so I'm gonna sneakily go ahead and merge it.