### PR TITLE
Improve extrapolation exceptions in PumpProbePulses 

### DIFF
--- a/src/extra/components/pulses.py
+++ b/src/extra/components/pulses.py
@@ -1288,6 +1288,8 @@ class PumpProbePulses(XrayPulses, OpticalLaserPulses):
         self._pulse_offset = None  # Allowed to be float!
         self._extrapolate = extrapolate
 
+        # Logic should always check these modes in exactly this order,
+        # see below.
         if bunch_table_position is not None:
             self._bunch_table_position = int(bunch_table_position)
         elif bunch_table_offset is not None:
@@ -1297,6 +1299,14 @@ class PumpProbePulses(XrayPulses, OpticalLaserPulses):
         else:
             raise ValueError('must specify one of bunch_table_position, '
                              'bunch_table_offset, pulse_offset')
+
+        if self._pulse_offset == 0:
+            # Implement this case via the bunch_table_offset mechanism
+            # to enable it to work even if there is only a single FEL
+            # pulse in any given train.
+            # These modes are always checked in the same order as above,
+            # while __repr__ accounts for this special case.
+            self._bunch_table_offset = 0
 
         if instrument is None:
             sase = None
@@ -1323,10 +1333,13 @@ class PumpProbePulses(XrayPulses, OpticalLaserPulses):
     def __repr__(self):
         if self._bunch_table_position is not None:
             offset_str = f'@{self._bunch_table_position}b'
+        elif self._pulse_offset is not None:
+            # This branch is intentionally ahead of buch_table_offset to
+            # still represent the case pulse_offset == 0 correctly even
+            # if it is implemented by bunch_table_offset = 0 internally.
+            offset_str = f'@SA{self._sase}{self._pulse_offset:+d}p'
         elif self._bunch_table_offset is not None:
             offset_str = f'@SA{self._sase}{self._bunch_table_offset:+d}b'
-        elif self._pulse_offset is not None:
-            offset_str = f'@SA{self._sase}{self._pulse_offset:+d}p'
 
         if self._with_timeserver:
             source_type = 'timeserver'

--- a/tests/test_components_pulses.py
+++ b/tests/test_components_pulses.py
@@ -709,8 +709,18 @@ def test_pump_probe_basic(mock_spb_aux_run, source):
         PumpProbePulses(run, source=source, instrument='123', pulse_offset=0)
 
 
-def test_pump_probe_defaults(mock_spb_aux_run):
+def test_pump_probe_specials(mock_spb_aux_run, mock_sqs_remi_run):
+    # Test full pulse IDs using defautl arguments.
     run = mock_spb_aux_run.select('SPB*').select_trains(np.s_[10:])
     np.testing.assert_equal(
         PumpProbePulses(run, pulse_offset=1).pulse_ids()[run.train_ids[0]],
         np.r_[1000:1306:6])
+
+    # Test single pulse case with pulse_offset == 0 (working through
+    # bunch_table_offset = 0 instead).
+    run = mock_sqs_remi_run.select_trains(np.s_[10:])
+    assert PumpProbePulses(run, pulse_offset=0).pulse_ids().any()
+
+    # Test single pulse case with pulse_offset != 0 (fails).
+    with pytest.raises(ValueError):
+        PumpProbePulses(run, pulse_offset=1).pulse_ids()


### PR DESCRIPTION
`PumpProbePulses` can anchor PPL pulses to FEL pulses via three different modes: `bunch_table_position`, `bunch_table_offset` and `pulse_offset`. While the first one always works, the second requires at least one while the third requires at least two pulses. Thus, an exception is raised if there are insufficient pulses in a given train to satisfy this mode. With `extrapolate=True` (default), an attempt is made to instead use the last working pattern.

This PR clarifies the exceptions, as this caused confusion in the field. It clearly distinguishes now between missing _one_ or _two_ pulses, and explains why. In addition it makes clear that it tried but failed to extrapolate, e.g. if it never saw a usable train yet.

In addition, it adds a special case for `pulse_offset=0` to also work with a single pulse by replacing it internally with `bunch_table_offset=0`.

@bermudei 