### PR TITLE
Fill pulse traces with NaN/-1 if data is too short

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -34,6 +34,7 @@ Changed:
   use by default (!221).
 - [`fit_gaussian()`][extra.utils.fit_gaussian] has a new `A_sign` parameter to
   specify the expected orientation of the peak (!222).
+- [`AdqRawChannel.pulse_data()`][extra.components.AdqRawChannel.pulse_data] no longer throws an exception if the pulse pattern refers to data beyond the acquired traces, but instead fills this with NaN or -1 depending on data type (!245).
 
 ## [2024.1.2]
 Added:

--- a/src/extra/components/adq.py
+++ b/src/extra/components/adq.py
@@ -1046,6 +1046,10 @@ class AdqRawChannel:
         This process depends on the `first_pulse_offset` and potentially
         `single_pulse_length` the component was initialized with.
 
+        If the pulse information refers to data beyond the acquired
+        traces, it is filled by np.nan for floating data types or
+        -1 for integer types.
+
         Args:
             labelled (bool, optional): Whether data is returned as a
                 labelled xarray (default) or unlabelled ndarray.


### PR DESCRIPTION
When using the pulse separation feature in the `AdqRawChannel` component, currently an exception is thrown if the underlying train trace is too short for all pulses. This is not very useful however, as there's little way for users to fix that in any way, e.g. only get data for those pulses that fit, or reduce the pattern asked for.

Rather than throwing an exception, this PR instead fills the missing samples with `NaN` (for floating types, most likely) or `-1` (in case of integer types, only with non-default settings). This maintains the information which data is missing, and the returned array can easily be truncated if desired.