### PR TITLE
Catch reported number of Timepix events exceeding buffer size 

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,9 @@
     pip install git+https://github.com/European-XFEL/EXtra.git
     ```
 
+Added:
+- [Timepix3][extra.components.Timepix3] to access raw hits and centroids from the Timepix3 detector (!231).
+
 Fixed:
 
 - Karabacon 3.0.10 is now supported by the [Scantool][extra.components.Scantool]
@@ -25,8 +28,6 @@ Fixed:
   uses them (!237).
 
 Changed:
-
-- [Timepix3][extra.components.Timepix3] to access raw hits and centroids from the Timepix3 detector (!231).
 - [`gaussian()`][extra.utils.gaussian] has a new `norm` parameter to allow
   disabling normalization, which [`fit_gaussian()`][extra.utils.fit_gaussian] will
   use by default (!221).

--- a/src/extra/components/timepix.py
+++ b/src/extra/components/timepix.py
@@ -551,8 +551,9 @@ class Timepix3:
                 False by default. If enabled, the pulse index dimension
                 will be forced to float.
             extended_columns (bool, optional): Whether to include the
-                original average and maximal time-over-threshold,
-                size and label for each centroid, False by default.
+                average and maximal time-over-threshold as well
+                as original time-of-arrival and labels for each
+                centroid, False by default.
             parallel (int or None, optional): Nunmber of parallel
                 processes to use, by default 10 or a quarter of all cores
                 whichever is lower. Any non-positive value or 1 disable
@@ -621,14 +622,17 @@ class Timepix3:
         # Build the data frame with centroids and the prepared index.
         df = pd.DataFrame.from_records(
             centroids.ravel()[centroids_rows][mask], index=index,
-            exclude=(['size', 'tot_avg', 'tot_max', 'toa']
+            exclude=(['tot_avg', 'tot_max', 'toa']
                      if not extended_columns else []))
         df.insert(2, 't', centroids_tof[mask])
+        df.rename(columns={'size': 'centroid_size'}, inplace=True)
 
         if extended_columns:
-            df.rename(columns={'size': 'centroid_size'}, inplace=True)
+            # Re-order centroid size.
+            df.insert(4, 'centroid_size', df.pop('centroid_size'))
+
             df['toa'] = centroids_toa[mask]  # Overwrite with modified data.
-            df.insert(6, 'toa', df.pop('toa'))  # Re-order ToA
+            df.insert(7, 'toa', df.pop('toa'))  # Re-order ToA
             df.insert(3, 'tot', df.pop('tot'))  # Re-order ToT.
             df['label'] = centroids_label[mask]
 

--- a/tests/mockdata/timepix.py
+++ b/tests/mockdata/timepix.py
@@ -20,7 +20,6 @@ stat_dt = np.dtype([('N_centroids', np.int64),
                     ('fraction_px_in_centroids', np.float64)])
 
 
-
 class TimepixCommon(DeviceBase):
     def _fill_hit_data(self, dset, min_val, max_val):
         val = np.nan if np.issubdtype(dset.dtype, np.floating) else 1

--- a/tests/test_components_timepix.py
+++ b/tests/test_components_timepix.py
@@ -185,6 +185,11 @@ def test_timepix3_pixel_events(monkeypatch, mock_sqs_timepix_run):
         tpx.pixel_events()
 
 
+def test_timepix3_exceeded_buffer(mock_timepix_exceeded_buffer_run):
+    with pytest.warns(RuntimeWarning):
+        Timepix3(mock_timepix_exceeded_buffer_run).pixel_events()
+
+
 def test_timepix3_centroid_events(mock_sqs_timepix_run):
     tpx = Timepix3(mock_sqs_timepix_run.deselect('SQS_EXTRA*'))
 

--- a/tests/test_components_timepix.py
+++ b/tests/test_components_timepix.py
@@ -66,7 +66,12 @@ def test_timepix3_data(mock_sqs_timepix_run, method):
     tpx = Timepix3(run)
     data = getattr(tpx, method)()
 
-    np.testing.assert_array_equal(data.columns, ['x', 'y', 't', 'tot'])
+    columns = list(data.columns)
+
+    if method == 'centroid_events':
+        assert columns.pop(-1) == 'centroid_size'
+
+    np.testing.assert_array_equal(columns, ['x', 'y', 't', 'tot'])
     assert data.index.names == ['trainId', 'pulseId']
 
     np.testing.assert_equal(
@@ -187,8 +192,8 @@ def test_timepix3_centroid_events(mock_sqs_timepix_run):
     centroids = tpx.centroid_events(extended_columns=True)
 
     np.testing.assert_array_equal(
-        centroids.columns, ['x', 'y', 't', 'tot', 'tot_avg', 'tot_max', 'toa',
-                            'centroid_size', 'label'])
+        centroids.columns, ['x', 'y', 't', 'tot', 'centroid_size',
+                            'tot_avg', 'tot_max', 'toa', 'label'])
 
     for _, d in centroids.groupby(['trainId', 'pulseId']):
         N = len(d)


### PR DESCRIPTION
Raw Timepix3 data is saved as ragged arrays with a fixed (but configurable) buffer size with the actual number of events recorded in a `data.size` key. While the device should prevent this from ever exceeding the buffer size, there is some data floating around where this happened. This PR makes sure the component can handle that, and in addition prints a warning as this is unlikely to be desired from data quality point of view.

Also includes a minor change to move the `centroid_size` column from the set of extended columns to default columns. Apart from someone iterating over columns (please don't), this should not break any existing columns.

@bj-s