### PR TITLE
Fix pulse slicing code to advance to next train on same pulse ID

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -26,6 +26,7 @@ Fixed:
 - [`Scan.plot_bin_by_steps()`][extra.components.Scan.plot_bin_by_steps] would
   previously ignore the `title`/`xlabel`/`ylabel` arguments, now it actually
   uses them (!237).
+- [`AdqRawChannel.pulse_data()`][extra.components.AdqRawChannel.pulse_data] no longer erroneously reads in the same train data for every pulse if there is only a single pulse per train (!259).
 
 Changed:
 - [`gaussian()`][extra.utils.gaussian] has a new `norm` parameter to allow

--- a/src/extra/components/_adq.pyx
+++ b/src/extra/components/_adq.pyx
@@ -24,8 +24,8 @@ def _reshape_flat_pulses(
     for i in range(pulse_ids.shape[0]):
         cur_pid = pulse_ids[i]
 
-        if cur_pid < prev_pid:
-            # Pulse ID decreasing means a new train started.
+        if cur_pid <= prev_pid:
+            # Pulse ID not increasing means a new train started.
             pid_offset = cur_pid
             j += 1
 


### PR DESCRIPTION
The native pulse slicing code compares subsequent pulse IDs to advance from train to train. In the case of a single pulse, this value never changes, thus reading the same (first) train over and over.