### PR TITLE
Relax contourpy dependecy to avoid version conflicts

### DIFF
--- a/.github/dependabot/constraints.txt
+++ b/.github/dependabot/constraints.txt
@@ -1,5 +1,5 @@
 cfelpyutils==2.1.0
-contourpy==1.3.1
+contourpy<=1.3.1
 cycler==0.12.1
 EXtra-data==1.18.0
 EXtra-geom==1.12.0


### PR DESCRIPTION
https://github.com/European-XFEL/EXtra/pull/256 appears to have introduced a dependency problem, as this version requires Python 3.10 and above.