### PR TITLE
Fix alignment between DLD data and external pulse information

### DIFF
--- a/src/extra/components/dld.py
+++ b/src/extra/components/dld.py
@@ -111,14 +111,13 @@ class DelayLineDetector:
             raise ValueError('missing pulse information for one or more '
                              'trains with data')
 
-        if len(entry_counts) < min(len(data_counts), len(pulse_counts)):
-            # Missing counts in one or more trains in data, select data
-            # and pulses down.
+        if len(entry_counts) < len(pulse_counts):
+            # Missing one or more trains in the actual data compared
+            # to the pulse information, select pulses down.
             from extra_data import by_id
             train_sel = by_id[entry_counts.index.to_numpy()]
 
             pulses = self._pulses.select_trains(train_sel)
-            kd = kd.select_trains(train_sel)
         else:
             pulses = self._pulses
 

--- a/tests/test_components_dld.py
+++ b/tests/test_components_dld.py
@@ -96,7 +96,7 @@ def test_dld_pulse_align(mock_sqs_remi_run):
         dld.hits()
 
     # Less trains for detector data.
-    dld = DelayLineDetector(run.select_trains(np.s_[:50]), pulses=pulses)
+    dld = DelayLineDetector(run.select_trains(np.s_[1:50]), pulses=pulses)
     hits = dld.hits()
     pd.testing.assert_frame_equal(hits, all_hits.loc[np.r_[10002:10050], :])
 


### PR DESCRIPTION
While most people use the DLD's internal pulse information, the component also supports supplying a `PulsePattern` object from the outside. Then, it may be necessary to align them.

The code supposed to handle that was unfortunately not working properly, as restricting `entry_counts` to only those rows with data before can easily cause the condition below to not properly activate. As a matter of fact, the test written for exactly this line hapened to pass because while it contained more trains, those had no pulses...

@bj-s 