### PR TITLE
Only average over trains dimension in Scan.bin_by_steps()

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,6 +27,9 @@ Fixed:
 - [`Scan.plot_bin_by_steps()`][extra.components.Scan.plot_bin_by_steps] would
   previously ignore the `title`/`xlabel`/`ylabel` arguments, now it actually
   uses them (!237).
+- [`Scan.bin_by_steps()][extra.components.Scan.plot_bin_by_steps] now preserves
+  any additional dimensions in the data to be binned, so it can produce e.g.
+  an average spectrum per scan step (!269).
 - [`AdqRawChannel.pulse_data()`][extra.components.AdqRawChannel.pulse_data] no longer erroneously reads in the same train data for every pulse if there is only a single pulse per train (!259).
 
 Changed:

--- a/src/extra/components/scan.py
+++ b/src/extra/components/scan.py
@@ -234,7 +234,7 @@ class Scan:
         chunks = self.split_by_steps(data)
 
         counts = np.array([len(c.coords['trainId']) for c in chunks])
-        signal = np.array([c.mean().item() for c in chunks])
+        signal = np.array([c.mean(dim='trainId').item() for c in chunks])
         uncertainty = np.array([c.std().item() for c in chunks])
         if uncertainty_method == "stderr":
             uncertainty /= np.sqrt(counts)

--- a/src/extra/components/scan.py
+++ b/src/extra/components/scan.py
@@ -233,21 +233,23 @@ class Scan:
 
         chunks = self.split_by_steps(data)
 
+        res = xr.concat(
+            [c.mean(dim='trainId') for c in chunks],
+            dim=xr.Variable("position", self.positions)
+        )
+
         counts = np.array([len(c.coords['trainId']) for c in chunks])
-        signal = np.array([c.mean(dim='trainId').item() for c in chunks])
         uncertainty = np.array([c.std().item() for c in chunks])
         if uncertainty_method == "stderr":
             uncertainty /= np.sqrt(counts)
 
-        return xr.DataArray(signal, dims=("position",),
-                            coords={"position": ("position", self.positions),
-                                    "uncertainty": ("position", uncertainty),
-                                    "counts": ("position", counts)},
-                            name=data.name,
-                            attrs={
-                                "motor": self.name,
-                                "uncertainty_method": uncertainty_method
-                            })
+        return res.assign_coords({
+            "uncertainty": ("position", uncertainty),
+            "counts": ("position", counts),
+        }).assign_attrs({
+            "motor": self.name,
+            "uncertainty_method": uncertainty_method,
+        }).rename(data.name)
 
     def plot_bin_by_steps(self, data, uncertainty_method="std",
                           title=None, xlabel=None, ylabel=None,

--- a/tests/test_components_scan.py
+++ b/tests/test_components_scan.py
@@ -106,3 +106,18 @@ def test_scan(mock_spb_aux_run):
     s.format()
     s.info()
     s.plot_bin_by_steps(data)
+
+
+def test_scan_bin_multidimensional(mock_spb_aux_run):
+    s = Scan(mock_spb_aux_run["MOTOR/MCMOTORYFACE"])
+
+    # Test scan binning with data with additional dimensionsn
+    xgm_intensity = mock_spb_aux_run[
+        "SPB_XTD9_XGM/DOOCS/MAIN:output", "data.intensityTD"
+    ].xarray(extra_dims=["pulse"])
+
+    binned = s.bin_by_steps(xgm_intensity)
+    assert binned.dims == ("position", "pulse")
+    # pulse is present as a dimension, but doesn't have coordinates
+    assert set(binned.coords.keys()) == {"position", "uncertainty", "counts"}
+    assert binned.shape == (10, 1000)


### PR DESCRIPTION
This came up at FXE: if you have an array with multiple values per train, such as a spectrum, you naturally want an average spectrum per scan step, but `scan.bin_by_steps(arr)` reduces it down to a single number per scan step instead.

This could theoretically break code that relies on it collapsing extra dimensions, but I'm not sure when you'd want that, and it's very easy to do further averaging on the results from this if you need to. So I hope we can just consider it a bug and fix it. :crossed_fingers: 

cc @bermudei 