### PR TITLE
Fix support for the `acquisition_time` with newer Karabacon versions

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,14 +7,14 @@
 
 ## [Unreleased]
 
-<!-- !!! note -->
-<!--     All of the changes here are deployed to our current environment, even though -->
-<!--     a release hasn't been made for them yet. If you want to have these updates -->
-<!--     in a personal environment you'll need to install the package from git. -->
+!!! note
+    All of the changes here are deployed to our current environment, even though
+    a release hasn't been made for them yet. If you want to have these updates
+    in a personal environment you'll need to install the package from git.
 
-<!--     ```bash title="Installation command" -->
-<!--     pip install git+https://github.com/European-XFEL/EXtra.git -->
-<!--     ``` -->
+    ```bash title="Installation command"
+    pip install git+https://github.com/European-XFEL/EXtra.git
+    ```
 
 Added:
 - [CookieboxCalibration][extra.recipes.CookieboxCalibration] to calibrate data from eTOFs after taking a calibration run (!284).
@@ -22,6 +22,9 @@ Added:
 
 Fixed:
 - [AdqRawChanne][extra.components.AdqRawChannel] now properly enumerates channels starting with 1 rather than 0 as in the Karabo device.
+- Fixed reading of the
+  [Scantool.acquisition_time][extra.components.Scantool.acquisition_time]
+  property for newer Scantool versions (!303).
 
 ## [2024.2]
 Added:

--- a/tests/test_components_scantool.py
+++ b/tests/test_components_scantool.py
@@ -69,11 +69,13 @@ def test_scantool():
     # Karabacon 3.0.10 renamed the acquisition time again to
     # deviceEnv.acquisitionTimes and data type changed from Double to VectorDouble.
     # Allows defining acq time per step.
+    mock_run_values["deviceEnv.acquisitionMode.value"] = "Continuous"
     mock_run_values["deviceEnv.acquisitionTimes.value"] = np.ones(1000, dtype=np.uint8)
     mock_run_values["deviceEnv.acquisitionTimes.value"][0] = 20
     del mock_run_values["acquisitionTime.value"]
-    
+
     scantool = Scantool(mock_run)
+    assert scantool.acquisition_time == 20
 
     # Smoke tests
     scantool.info()


### PR DESCRIPTION
Before it would grab the entire vector rather than the first value in continuous scans. This will need some more tweaking in the future to select the first N values (where N is the number of steps) for non-continuous scans.