### PR TITLE
Fix pulse alignment in ADQ raw data component

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,6 +22,7 @@ Added:
 - Exposed detector data components from `extra_data` in `extra.components` (AGIPD1M, AGIPD500K, DSSC1M, JUNGFRAU, LPD1M).
 
 Fixed:
+- Fixed issues with pulse separation in [AdqRawChannel][extra.components.AdqRawChannel] with variable pulse patterns and those with trains missing ADQ data (!310).
 - [AdqRawChanne][extra.components.AdqRawChannel] now properly enumerates channels starting with 1 rather than 0 as in the Karabo device.
 - Fixed reading of the
   [Scantool.acquisition_time][extra.components.Scantool.acquisition_time]

--- a/src/extra/components/adq.py
+++ b/src/extra/components/adq.py
@@ -411,7 +411,7 @@ class AdqRawChannel:
 
         if pulses_end > data.shape[-1]:
             raise ValueError(f'trace axis too short for {num_pulses} pulses '
-                             f'located at {pulses_start}:{pulses_end}]')
+                             f'located at {pulses_start}:{pulses_end}')
 
         return data[..., pulses_start:pulses_end].reshape(
             *data.shape[:-1], num_pulses, samples_per_pulse)

--- a/src/extra/components/adq.py
+++ b/src/extra/components/adq.py
@@ -390,8 +390,8 @@ class AdqRawChannel:
 
         # Generate offsets of first pulse and last pulse of each
         # train relative to all pulses.
-        pulse_first = num_pulses.cumsum() - num_pulses.iloc[0]
-        pulse_last = pulse_first + num_pulses
+        pulse_last = num_pulses.cumsum()
+        pulse_first = pulse_last - num_pulses
 
         # Combine pulse layout into a single dataframe.
         # TODO: samples_per_pulses is currently assumed to be constant


### PR DESCRIPTION
Speaking so much of (train) alignment issues last Friday, there were actually some lurking in the ADQ raw data component. 

This PR fixes two independent issues separated by commits:

1. fc80996c80177030b0f6d6e2e8f2b4e8cb827152: the component did not actually align the pulse information it uses internally to the actual trains for which the ADQ saved data for. This did not actually cause issues in most circumstances, as the pulse data is associated via train IDs, but could cause the `pasha` kernel in `.pulse_edges()` to break. For consistency, ADQ data is now always aligned before, and the pulse information selected properly.

2. 163f63b4cc1f3cdace98d0a1e0aece029a0315fc: This was a quite tricky bug in practice, as it only occured for variable-pulse runs. The `._prepare_pulses()` generates a dataframe with data about the pulse pattern per train including the first and last index in a global pulse list:

    |  | `first` | `last` |
    | - | - | - |
    | $0$ | $0$ | $N_0$ |
    | $1$ | $N_0$ | $N_0+N_1$ |
    | $2$ | $N_0+N_1$ | $N_0+N_1+N_2$ |
    | $3$ | $N_0+N_1+N_2$ | $N_0+N_1+N_2+N_3$ |
    | $m$ | $\sum \limits_{i=0}^{m-1} N_i$ | $\sum \limits_{i=0}^{m} N_i$ |

    The original implementation however gave this:

    |  | `first` | `last` |
    | - | - | - |
    | $0$ | $0$ | $N_0$ |
    | $1$ | $N_1$ | $2 N_1$ |
    | $2$ | $N_1+N_2$ | $N_1+2 N_2$ |
    | $3$ | $N_1+N_2+N_3$ | $N_1+N_2+2 N_3$ |
    | $m$ | $\sum \limits_{i=1}^{m} N_i$ | $\sum \limits_{i=1}^{m} N_i + N_m$ |

    This is naturally identical for $N_i = {\rm const}$, and might even go unnoticed for small variations in pulse count. In the past experiment however, we were switching between 2 and 92 pulses, which sooner or later caused the code to break by jumping train boundaries.
