### PR TITLE
Use _reshape_flat_pulses rather than _reshape_pulses_by_train for pulse splitting

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -23,6 +23,7 @@ Added:
 
 Fixed:
 - Fixed [PumpProbePattern.is_constant_pattern()][extra.components.PumpProbePattern.is_constant_pattern] to properly take pump probe flags into account when determining whether a pattern is constant (!313).
+- [AdqRawChannel.pulse_edges()][extra.components.AdqRawChannel.pulse_edges] now also supports data where the trace is too short for the actual number of pulses present (!312).
 - Fixed issues with pulse separation in [AdqRawChannel][extra.components.AdqRawChannel] with variable pulse patterns and those with trains missing ADQ data (!310).
 - [AdqRawChanne][extra.components.AdqRawChannel] now properly enumerates channels starting with 1 rather than 0 as in the Karabo device.
 - Fixed reading of the


### PR DESCRIPTION
There are methods in `AdqRawChannel` to split train traces into pulse traces, via simple reshaping and through a Cython function. The latter exists mostly to allow for flat pulse axes with non-constant pulse counts, but can also handle train traces that are too short for the number of pulses present.

`AdqRawChannel.pulse_edges()` and `AdqRawChannel.pulse_edge_array()` used the former method so far, which ran into the trace length problem for a couple of runs. Hence, this PR changes them to use the latter method instead. There is an insignificant speed overhead between the two, which in most cases is entirely overshadowed by IO and edge discrimination.