### PR TITLE
Account for additional indices in PulsePattern.is_constant_pattern

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,6 +22,7 @@ Added:
 - Exposed detector data components from `extra_data` in `extra.components` (AGIPD1M, AGIPD500K, DSSC1M, JUNGFRAU, LPD1M).
 
 Fixed:
+- Fixed [PumpProbePattern.is_constant_pattern()][extra.components.PumpProbePattern.is_constant_pattern] to properly take pump probe flags into account when determining whether a pattern is constant (!313).
 - Fixed issues with pulse separation in [AdqRawChannel][extra.components.AdqRawChannel] with variable pulse patterns and those with trains missing ADQ data (!310).
 - [AdqRawChanne][extra.components.AdqRawChannel] now properly enumerates channels starting with 1 rather than 0 as in the Karabo device.
 - Fixed reading of the

--- a/src/extra/components/pulses.py
+++ b/src/extra/components/pulses.py
@@ -315,8 +315,15 @@ class PulsePattern:
         if pids_by_train.count().unique().size > 1:
             return False
 
-        # Are the pulse IDs in each pulse position identical?
-        if any([len(x) > 1 for x in pulse_ids.groupby(level=1).unique()]):
+        # Is the pulse data (ID and any other index flags) in each pulse
+        # position identical?
+        # To do this, move any indices beyond train and pulse into
+        # columns, and then group by pulse.
+        pulse_data = pulse_ids.reset_index(pulse_ids.index.names[2:])
+        data_by_pulse = pulse_data.groupby(level=1)
+        if any([len(unique_rows) > 1
+                for column in pulse_data.columns
+                for unique_rows in data_by_pulse[column].unique()]):
             return False
 
         if include_empty_trains:


### PR DESCRIPTION
Thomas noticed that `PulsePattern.is_constant_pattern` does not take the additional flags introduced by the `PumpProbePulses` multi index into account, specifically which pulses are pumped and unpumped. As such, an alternating train pattern was incorrectly described as *constant*.

This PR extends the method in an hopefully forwards-compatible way by shifting any additional indices into columns of a dataframe, and check the constant condition for all of them.

Creating this for testing purposes immediately, will follow up with tests later this week.