### PR TITLE
Add PumpProbePulses.pumped_pulses_ratios()

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,6 +18,8 @@
 
 Added:
 
+- [PumpProbePattern.pumped_pulses_ratios()][extra.components.PumpProbePattern.pumped_pulses_ratios]
+  determining the ratio of pumped pulses per train (!317).
 - [TimeserverPulses.plot_xray_patterns][extra.components.pulses.TimeserverPulses.plot_xray_patterns]
   to visualize the X-ray pulse patterns present in timeserver data (!499).
 - [AdqRawChannel.train_data][extra.components.AdqRawChannel.train_data] and

--- a/src/extra/components/pulses.py
+++ b/src/extra/components/pulses.py
@@ -2248,3 +2248,12 @@ class DldPulses(PulsePattern):
         warn("Use triggers() instead of get_triggers()",
              DeprecationWarning, stacklevel=2)
         return self.triggers(*args, **kwargs)
+
+    @wraps(PumpProbePulses.pumped_pulses_ratios)
+    def pumped_pulses_ratios(self, *args, **kwargs):
+        pids = self.pulse_ids(copy=False)
+
+        if 'ppl' not in pids.index.names:
+            raise ValueError('only available with PPL information')
+
+        return PumpProbePulses.pumped_pulses_ratios(self, *args, **kwargs)

--- a/src/extra/components/pulses.py
+++ b/src/extra/components/pulses.py
@@ -1985,6 +1985,59 @@ class PumpProbePulses(XrayPulses, OpticalLaserPulses):
         else:
             raise ValueError(f"{field=!r} parameter was not 'fel'/'ppl'/None")
 
+    def pumped_pulses_ratios(self, ppl_only_value=np.nan, labelled=True):
+        """Determine ratio of pumped pulses per train.
+
+        Args:
+            ppl_only_value (float, optional): Value for trains only
+                containing PPL pulses, same value as for pulses without
+                any pulses (np.nan) by default.
+            labelled (bool, optional): Whether a labelled pandas Series
+                (default) or unlabelled numpy array is returned.
+
+        Returns:
+            (pandas.Series or numpy.ndarray): Number of pulses per
+                train, indexed by train ID if labelled is True.
+        """
+
+        pids = self.pulse_ids(copy=False)
+
+        try:
+            fel_count = pids[:, :, True, :].groupby('trainId').count()
+        except KeyError:
+            fel_count = pd.Series([])
+
+        try:
+            pumped_count = pids[:, :, True, True].groupby('trainId').count()
+        except KeyError:
+            pumped_count = pd.Series([])
+
+        # Compute the ratio for trains with at least one pumped pulse.
+        ratios = pumped_count / fel_count.loc[pumped_count.index]
+
+        # Extend the series to all expected trains, filling with NaN.
+        ratios = self._extend_all_trains(ratios, np.nan)
+
+        # Set those trains with all unpumped pulses to 0.0.
+        fel_only_index = fel_count.index.difference(pumped_count.index)
+        ratios.loc[fel_only_index] = 0.0
+
+        # Set those trains with no FEL pulses to the desired fill value.
+        if ppl_only_value is not np.nan:
+            # If one only cares for the index labels of a groupby,
+            # pd.SeriesGroupBy.count() is indeed faster than
+            # pd.SeriesGroupBy.groups, likely due additional objects
+            # created by the latter.
+            try:
+                ppl_only_index = pids[:, :, :, True].groupby('trainId') \
+                    .count().index.difference(fel_count.index)
+            except KeyError:
+                pass
+            else:
+                ratios.loc[ppl_only_index] = ppl_only_value
+
+        return ratios if labelled else ratios.to_numpy()
+
 
 class ManualPulses(PulsePattern):
     """Manual pulse patterns.

--- a/tests/mockdata/timeserver.py
+++ b/tests/mockdata/timeserver.py
@@ -32,6 +32,10 @@ def _fill_bunch_pattern_table(table, N, offset=10):
     # LP_SPB
     table[offset//2:, 0:300:6] |= int(PPL_BITS.LP_SPB)
 
+    # LP_SASE
+    table[:N//2, 0:200:8] |= int(PPL_BITS.LP_SASE2)
+    table[N//2:N//2+N//4, 0:200:16] |= int(PPL_BITS.LP_SASE2)
+
 
 class Timeserver(DeviceBase):
     control_keys = [

--- a/tests/test_components_pulses.py
+++ b/tests/test_components_pulses.py
@@ -470,8 +470,8 @@ def test_optical_laser_specials(mock_spb_aux_run):
     assert (pulses.pulse_counts() == 0).all()
 
     # Different laser seed by string.
-    pulses = OpticalLaserPulses(run, ppl_seed='MID')
-    assert pulses.ppl_seed == PPL_BITS.LP_SASE2
+    pulses = OpticalLaserPulses(run, ppl_seed='SQS')
+    assert pulses.ppl_seed == PPL_BITS.LP_SQS
     assert (pulses.pulse_counts() == 0).all()
 
     # Full run with two timeservers.
@@ -746,21 +746,29 @@ def test_pump_probe_specials(mock_spb_aux_run, mock_sqs_remi_run):
     with pytest.raises(ValueError):
         PumpProbePulses(run, pulse_offset=1).pulse_ids()
 
-    # Test a pattern constant in pulse IDs, but having different pump
-    # probe flags (e.g. an alternating laser on/off pattern).
-    pulses = PumpProbePulses(mock_sqs_remi_run[10:], pulse_offset=0)
+    # Test changing patterns
+    # SASE2 FEL and PPL have four train regions:
+    # - 0:10 with no FEL but PPL
+    # - 10:50 with 63 FEL and 25 PPL
+    # - 50:75 with 63 FEL and 13 PPL
+    # - 75:100 with 63 FEL and no PPL
+    pulses = PumpProbePulses(mock_spb_aux_run.select('SPB*'),
+                             instrument='MID', bunch_table_position=1500)
 
-    # Inject custom cached pulse ID, but make sure to use the same trains.
-    train_ids = pulses._get_train_ids()
-    pulse_indices = np.arange(20)
-    pulses._pulse_ids = pd.Series(
-        np.tile(1000 + pulse_indices * 8, len(train_ids)),
-        pd.MultiIndex.from_tuples(
-            [(train_id, pulse_idx, True, (train_id % 2) == 0)
-            for train_id in train_ids for pulse_idx in pulse_indices],
-            names=('trainId', 'pulseIndex', 'fel', 'ppl')))
+    assert pulses.select_trains(np.s_[:10]).is_constant_pattern()
+    assert not pulses.select_trains(np.s_[:15]).is_constant_pattern()
+    assert pulses.select_trains(np.s_[10:50]).is_constant_pattern()
+    assert not pulses.select_trains(np.s_[45:55]).is_constant_pattern()
+    assert pulses.select_trains(np.s_[50:75]).is_constant_pattern()
+    assert not pulses.select_trains(np.s_[70:80]).is_constant_pattern()
+    assert pulses.select_trains(np.s_[75:]).is_constant_pattern()
 
-    assert not pulses.is_constant_pattern()
+    for args, cmp in [((), np.isnan), ((np.inf,), np.isinf)]:
+        ratios = pulses.pumped_pulses_ratios(*args)
+        assert cmp(ratios.iloc[:10]).all()
+        np.testing.assert_allclose(ratios.iloc[10:50], 25/63)
+        np.testing.assert_allclose(ratios.iloc[50:75], 13/63)
+        np.testing.assert_allclose(ratios.iloc[75:], 0.0)
 
 
 def test_manual_pulses():


### PR DESCRIPTION
I recently needed to frequently distinguish regular trains with all or most pulses pumped vs trains where intentionally only few or no pulses are pumped for reference. This was way more work than I wanted to, mostly because of necessary train alignment between these modes.

This PR adds a corresponding method `.pumped_pulses_ratios()` returning such a series automatically.

@takluyver This could also be used to distinguish pump-probe patterns 