### PR TITLE
Allow Scan.plot_bin_by_steps() to work for 2D binned results

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -31,6 +31,8 @@ Fixed:
 - Fixed reading of the
   [Scantool.acquisition_time][extra.components.Scantool.acquisition_time]
   property for newer Scantool versions (!303).
+- Fixed [Scan.plot_bin_by_steps()][extra.components.Scan.plot_bin_by_steps] to show 2D
+  data (!320).
 
 ## [2024.2]
 Added:

--- a/src/extra/components/scan.py
+++ b/src/extra/components/scan.py
@@ -284,25 +284,39 @@ class Scan:
 
         binned_data = self.bin_by_steps(data)
 
-        uncertainty_label = "standard deviation" if uncertainty_method == "std" else "standard error"
-        ax.plot(binned_data.position, binned_data, "-o", markersize=4, label=f"Uncertainty: {uncertainty_label}")
-        ax.fill_between(binned_data.position,
-                        binned_data - binned_data.uncertainty,
-                        binned_data + binned_data.uncertainty,
-                        alpha=0.5)
-        ax.grid()
-        ax.set_xlabel(self.name if xlabel is None else xlabel)
+        if binned_data.ndim == 1:
+            uncertainty_label = "standard deviation" if uncertainty_method == "std" else "standard error"
+            binned_data.plot.line("-o", markersize=4, label=f"Uncertainty: {uncertainty_label}")
+            ax.fill_between(binned_data.position,
+                            binned_data - binned_data.uncertainty,
+                            binned_data + binned_data.uncertainty,
+                            alpha=0.5)
+            ax.grid()
+            ax.legend()
 
+            if binned_data.name is not None:
+                yaxis = binned_data.name
+            else:
+                ylabel = "Signal [arb. u.]" if ylabel is None else ylabel
+                yaxis = "Signal"
 
-        if binned_data.name is not None:
-            ax.set_ylabel(binned_data.name if ylabel is None else ylabel)
-            yaxis = binned_data.name
-        else:
-            ax.set_ylabel("Signal [arb. u.]" if ylabel is None else ylabel)
-            yaxis = "Signal"
+            if xlabel is None:
+                xlabel = self.name
 
-        ax.legend()
-        ax.set_title(f"{yaxis} vs {self.name}" if title is None else title)
+            if title is None:
+                title = f"{yaxis} vs {self.name}"
+        else:  # 2D
+            binned_data.plot()
+
+            if ylabel is None:
+                ylabel = self.name
+
+        if title:
+            ax.set_title(title)
+        if xlabel:
+            ax.set_xlabel(xlabel)
+        if ylabel:
+            ax.set_ylabel(ylabel)
 
         return ax
 

--- a/tests/test_components_scan.py
+++ b/tests/test_components_scan.py
@@ -121,3 +121,6 @@ def test_scan_bin_multidimensional(mock_spb_aux_run):
     # pulse is present as a dimension, but doesn't have coordinates
     assert set(binned.coords.keys()) == {"position", "uncertainty", "counts"}
     assert binned.shape == (10, 1000)
+
+    # Smoke test
+    s.plot_bin_by_steps(xgm_intensity)


### PR DESCRIPTION
In #269, we fixed the `bin_by_steps()` method to only average over the trains dimension, so you can get e.g. average spectra. But I didn't think about `plot_bin_by_steps()` at the time. This supports plotting the same information, mostly using xarray's defaults:

![image](https://github.com/user-attachments/assets/d039ed2e-7522-4ec3-9df9-de76960545c0)
