### PR TITLE
Fix Timepix3.spatial_bins when using custom arguments

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -23,6 +23,9 @@ Added:
 - [Grating2DCalibration][extra.recipes.Grating2DCalibration] to calibrate data from a 2D grating detector (!284).
 - Exposed detector data components from `extra_data` in `extra.components` (AGIPD1M, AGIPD500K, DSSC1M, JUNGFRAU, LPD1M).
 
+Changed:
+- [Timepix3.spatial_bins()] is now a static method.
+
 Fixed:
 - Fixed [PumpProbePattern.is_constant_pattern()][extra.components.PumpProbePattern.is_constant_pattern] to properly take pump probe flags into account when determining whether a pattern is constant (!313).
 - [AdqRawChannel.pulse_edges()][extra.components.AdqRawChannel.pulse_edges] now also supports data where the trace is too short for the actual number of pulses present (!312).
@@ -37,9 +40,6 @@ Added:
 
 - [Timepix3][extra.components.Timepix3] to access raw hits and centroids from the Timepix3 detector (!231).
 - [Scan.plot()][extra.components.Scan.plot] now allows passing a `figsize` (!262).
-
-Added:
-
 - [JF4MHalfMotors][extra.components.JF4MHalfMotors] to access positions of motors moving halfs of Jungfrau detector (!224).
 
 Fixed:

--- a/src/extra/components/timepix.py
+++ b/src/extra/components/timepix.py
@@ -410,17 +410,18 @@ class Timepix3:
     def centroid_labels_key(self):
         return self.centroids_instrument_src['data.labels']
 
-    def spatial_bins(self, min_pos=0, max_pos=256, bins_per_px=1):
+    @staticmethod
+    def spatial_bins(min_pos=0, max_pos=255, bins_per_px=1):
         """Build suitable bin edges for Timepix position data.
 
-        The bins are centered around integer pixel position to avoid
-        binning artifacts.
+        The bins are centered around pixel position to avoid binning
+        artifacts otherwise commonly appearing with Timepix data.
 
         Args:
             min_pos (int, optional): Lower spatial boundary,
                 0 by default.
             max_pos (int, optional): Upper spatial boundary,
-                256 by default.
+                255 by default.
             bins_per_px (int, optional): Number of bins per pixel,
                 1 by default
 
@@ -428,7 +429,8 @@ class Timepix3:
             bins (numpy.ndarray): Spatial bin edges.
         """
 
-        return np.arange(min_pos, max_pos, 1/bins_per_px) - 0.5/bins_per_px
+        return np.arange(min_pos, max_pos + 2 / bins_per_px, 1 / bins_per_px) \
+            - 0.5 / bins_per_px
 
     def pixel_events(self, pulse_dim='pulseId', toa_offset=0.0,
                      timewalk_lut=None, out_of_pulse_events=False,

--- a/src/extra/components/timepix.py
+++ b/src/extra/components/timepix.py
@@ -46,7 +46,7 @@ class Timepix3:
 
     # Only support single-chip detectors for now.
     _instrument_re = re.compile(
-        r'^(\w{3}_\w+_TIMEPIX)\/(CAM|DET|CAL)\/\w+:daqOutput.chip0$')
+        r'^(\w{3,6}_\w+_TIMEPIX)\/(CAM|DET|CAL)\/\w+:daqOutput.chip0$')
 
     def __init__(self, data, detector=None, pulses=None, **kwargs):
         # Always run detection to potentially find the raw and


### PR DESCRIPTION
@bj-s found some issues with `Timepix3.spatial_bins` with its custom arguments in https://github.com/European-XFEL/EXtra/issues/323 and kindly provided a proper implementation alongside it.

Also changes the method to @staticmethod and relaxes the regexp used to include 6-word topics like `SQSLAB`.

Closes https://github.com/European-XFEL/EXtra/issues/323