### PR TITLE
Add support for passing a union of runs to Scantool

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,6 +24,8 @@ Added:
 - [Grating2DCalibration][extra.recipes.Grating2DCalibration] to calibrate data from a 2D grating detector (!284).
 - Exposed detector data components from `extra_data` in `extra.components`
   (AGIPD1M, AGIPD500K, DSSC1M, JUNGFRAU, LPD1M) (!177).
+- Added support for passing a union of runs to
+  [Scantool][extra.components.Scantool] (!327).
 
 Changed:
 - [Timepix3.spatial_bins()] is now a static method.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ from .mockdata.dld import ReconstructedDld
 from .mockdata.timepix import Timepix3Receiver, Timepix3Centroids
 from .mockdata.timeserver import PulsePatternDecoder, Timeserver
 from .mockdata.xgm import XGM, XGMD, XGMReduced
+from .mockdata.karabacon import Karabacon
 
 
 @pytest.fixture(scope='session')
@@ -156,3 +157,13 @@ def mock_timepix_exceeded_buffer_run(mock_sqs_timepix_directory):
             size_dset[np.argmax(size_dset)] += tpx_root['data/x'].shape[1]
 
         yield RunDirectory(td).deselect('SQS_EXTRA*')
+
+@pytest.fixture(scope="function")
+def mock_scantool_run():
+    sources = [
+        Karabacon("FXE_DAQ_SCAN/MDL/KARABACON"),
+    ]
+
+    with TemporaryDirectory() as td:
+        write_file(Path(td) / 'RAW-R0001-DA01-S00000.h5', sources, 100)
+        yield RunDirectory(td)

--- a/tests/mockdata/karabacon.py
+++ b/tests/mockdata/karabacon.py
@@ -1,0 +1,42 @@
+import h5py
+import numpy as np
+from extra_data.tests.mockdata.base import DeviceBase
+
+str_dtype = h5py.special_dtype(vlen=str)
+
+class Karabacon(DeviceBase):
+    control_keys = [
+        ("isMoving", "uint8", ()),
+        ("deviceEnv/acquisitionMode", str_dtype, (1,)),
+        ("deviceEnv/acquisitionTimes", "f8", (10_000,)),
+        ("deviceEnv/activeMotors", str_dtype, (1000,)),
+        ("scanEnv/scanType", str_dtype, (1,)),
+        ("scanEnv/steps", "int32", (6,)),
+        ("scanEnv/startPoints", "f8", (6,)),
+        ("scanEnv/stopPoints", "f8", (6,)),
+        ("actualConfiguration", str_dtype, (1,))
+    ]
+
+    def write_control(self, f):
+        super().write_control(f)
+
+        # Values taken from p7948, run 154
+        mock_values = {
+            "deviceEnv/acquisitionMode": np.array([b'Continuous Averaged'], dtype=object),
+            "deviceEnv/acquisitionTimes": np.insert(np.ones(9999), 0, 30),
+            "deviceEnv/activeMotors": np.array([b"ppl_odl"] + [b""] * 999, dtype=object),
+            "scanEnv/scanType": np.array([b'dscan'], dtype=object),
+            "scanEnv/steps": np.array([20,  1,  1,  1,  1,  1], dtype=np.int32),
+            "scanEnv/startPoints": np.array([-15., 1., 1., 1., 1., 1.]),
+            "scanEnv/stopPoints": np.array([25., 1., 1., 1., 1., 1.]),
+            "actualConfiguration": np.array([b"--- Motors: ['FXE_AUXT_LIC/DOOCS/PPODL:default']--- Data Sources: ['FXE_EXP_ONC/METRO/USER_XAS:output0.schema.data.value', 'FXE_EXP_ONC/METRO/USER_XAS:output1.schema.data.value', 'FXE_EXP_ONC/METRO/USER_XAS:output2.schema.data.value', 'FXE_EXP_ONC/METRO/USER_XAS:output6.schema.data.value', 'FXE_EXP_ONC/METRO/USER_XAS:output7.schema.data.value', 'FXE_EXP_ONC/METRO/USER_XAS:output8.schema.data.value']--- Triggers: []"],
+                                                  dtype=object)
+        }
+
+
+        for key, value in mock_values.items():
+            ds_key = f"CONTROL/{self.device_id}/{key}/value"
+            ds = f[ds_key]
+            ntrains = ds.shape[0]
+            for i in range(ntrains):
+                ds[i, :] = value


### PR DESCRIPTION
This is for convenience when working with combined runs. The output looks like this:
![image](https://github.com/user-attachments/assets/5aaaa327-8f73-45d9-9bba-1ea1917e9c0c)

The bulk of the changes are to support reading the scantool settings from CONTROL data instead of RUN data.