### PR TITLE
~~Fix~~ Prevent building with Cython 3.1

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -39,7 +39,8 @@ Fixed:
   property for newer Scantool versions (!303).
 - Fixed [Scan.plot_bin_by_steps()][extra.components.Scan.plot_bin_by_steps] to show 2D
   data (!320).
-- Fixed building with Cython 3.1 (!328).
+- Restrict the version of Cython used to build while we figure out an issue with
+  Cython 3.1 (!328).
 
 ## [2024.2]
 Added:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -39,6 +39,7 @@ Fixed:
   property for newer Scantool versions (!303).
 - Fixed [Scan.plot_bin_by_steps()][extra.components.Scan.plot_bin_by_steps] to show 2D
   data (!320).
+- Fixed building with Cython 3.1 (!328).
 
 ## [2024.2]
 Added:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61", "wheel", "setuptools_scm[toml]==7.1.0", "numpy", "cython"]
+requires = ["setuptools>=61", "wheel", "setuptools_scm[toml]==7.1.0", "numpy", "cython<3.1"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.dynamic]

--- a/src/extra/components/_adq.pyx
+++ b/src/extra/components/_adq.pyx
@@ -4,7 +4,7 @@
 from cython cimport numeric
 from libc.limits cimport INT_MAX
 from libc.string cimport memcpy
-from numpy.math cimport NAN
+from libc.math cimport NAN
 
 
 def _reshape_flat_pulses(


### PR DESCRIPTION
Use libc.math in Cython code instead of numpy.math. From [Cython's release notes](https://cython.readthedocs.io/en/latest/src/changes.html#beta-1-2025-04-03):

> The numpy.math cimport module has been deprecated. Usages should be replaced by libc.math. (Github issue [#6743](https://github.com/cython/cython/issues/6743))