### PR TITLE
Allow building with Cython 3.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,11 @@
 [build-system]
-requires = ["setuptools>=61", "wheel", "setuptools_scm[toml]==7.1.0", "numpy", "cython<3.1"]
+requires = [
+    "setuptools>=61",
+    "wheel",
+    "setuptools_scm[toml]==7.1.0",
+    "numpy",
+    "cython!=3.1.0",  # Avoiding https://github.com/cython/cython/issues/6855
+]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.dynamic]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ requires = [
     "wheel",
     "setuptools_scm[toml]==7.1.0",
     "numpy",
-    "cython!=3.1.0",  # Avoiding https://github.com/cython/cython/issues/6855
+    "cython !=3.1.0,!=3.1.1",  # Avoiding https://github.com/cython/cython/issues/6855
+                               # and https://github.com/cython/cython/issues/6897
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
Follow up to #328. The issue with inspecting function parameters when building with Cython 3.1.0 has been fixed.