### PR TITLE
Align pulse information to the ADQ trains before using them

### DIFF
--- a/tests/test_components_adq.py
+++ b/tests/test_components_adq.py
@@ -229,6 +229,22 @@ def test_pulse_data(mock_sqs_remi_run):
         # Test whether all pulses after the trace are nan.
         assert np.isnan(max_by_pulse[21:50]).all()
 
+    # Use pulse information with not all trains available.
+    ch = AdqRawChannel(
+        mock_sqs_remi_run, '3B', digitizer='SQS_DIGITIZER_UTC2',
+        pulses=XrayPulses(mock_sqs_remi_run.select_trains(np.s_[:-10])))
+
+    with pytest.raises(ValueError):
+        ch.pulse_data()
+
+    # Use pulse information with more trains available.
+    ch = AdqRawChannel(
+        mock_sqs_remi_run.select_trains(np.s_[:-10]), '3B',
+        digitizer='SQS_DIGITIZER_UTC2', pulses=pulses)
+    data = ch.pulse_data()
+
+    assert data.shape[0] < pulses.pulse_counts().sum()
+
 
 def test_train_edge_array(mock_sqs_remi_run):
     ch = AdqRawChannel(mock_sqs_remi_run, '3B', digitizer='SQS_DIGITIZER_UTC2')


### PR DESCRIPTION
While https://github.com/European-XFEL/EXtra/pull/310 fixed the issue of pulse information *lacking* trains, it did not bother when pulse information has *more* trains. In combination with https://github.com/European-XFEL/EXtra/pull/245, it caused `AdqRawChannel.pulse_data()` to apparently return more trains than `AdqRawChannel.train_data()` as it's diligently filling anything with pulse information with fill values.

After fixing the above, I noticed the coordinates naturally required alignment as well. This PR addresses all of this issues by doing this upfront now, and added a test failing on the previous version. 