### PR TITLE
Add support for DataArrays to imshow2

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,6 +24,8 @@ Added:
 - [Grating2DCalibration][extra.recipes.Grating2DCalibration] to calibrate data from a 2D grating detector (!284).
 - Exposed detector data components from `extra_data` in `extra.components`
   (AGIPD1M, AGIPD500K, DSSC1M, JUNGFRAU, LPD1M) (!177).
+- [imshow2][extra.utils.imshow2] now supports plotting 2D
+  [DataArray][xarray.DataArray]s properly (!333).
 
 Changed:
 - [Timepix3.spatial_bins()] is now a static method.

--- a/src/extra/components/xgm.py
+++ b/src/extra/components/xgm.py
@@ -587,11 +587,9 @@ class XGM:
         pulse_energy = self.pulse_energy(sase)
 
         from extra.utils import imshow2
-        im = imshow2(pulse_energy, ax=ax, aspect="auto")
+        im = imshow2(pulse_energy, ax=ax)
 
         self._set_plot_title("XGM pulse energy heatmap", ax, sase, minimal_title)
-        ax.set_xlabel("Pulse")
-        ax.set_ylabel("Train")
 
         colorbar = fig.colorbar(im)
         colorbar.ax.set_ylabel("Energy [μJ]")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,12 +1,15 @@
-
 import numpy as np
+import xarray as xr
 
 from extra.utils import imshow2, fit_gaussian, gaussian
 
 
-def test_scaled_imshow():
+def test_imshow2():
     # Smoke test
     image = np.random.rand(100, 100)
+    imshow2(image)
+
+    image = xr.DataArray(image, dims=("foo", "bar"))
     imshow2(image)
 
 


### PR DESCRIPTION
The advantage is that we can now get proper labels/axis limits automatically:
```python
plt.figure()
imshow2(azint.squeeze())
```
![image](https://github.com/user-attachments/assets/6cb2f214-0cb9-464b-8cf5-a4b1f60edecc)
