### PR TITLE
Always use the passed axis in Scan.plot_bin_by_steps()

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -41,6 +41,9 @@ Fixed:
   data (!320).
 - Restrict the version of Cython used to build while we figure out an issue with
   Cython 3.1 (!328).
+- Fixed behaviour of
+  [Scan.plot_bin_by_steps()][extra.components.Scan.plot_bin_by_steps] when
+  passed a custom axis (!334).
 
 ## [2024.2]
 Added:

--- a/src/extra/components/scan.py
+++ b/src/extra/components/scan.py
@@ -286,7 +286,7 @@ class Scan:
 
         if binned_data.ndim == 1:
             uncertainty_label = "standard deviation" if uncertainty_method == "std" else "standard error"
-            binned_data.plot.line("-o", markersize=4, label=f"Uncertainty: {uncertainty_label}")
+            binned_data.plot.line("-o", markersize=4, label=f"Uncertainty: {uncertainty_label}", ax=ax)
             ax.fill_between(binned_data.position,
                             binned_data - binned_data.uncertainty,
                             binned_data + binned_data.uncertainty,


### PR DESCRIPTION
Otherwise it might use a different axis:
```python
fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(9, 5))
scan.plot_bin_by_steps(results.intensity.squeeze(), ax=ax1)

fig.tight_layout()
```
![image](https://github.com/user-attachments/assets/d9f2a8c2-fe57-4a1c-8a6a-b81fee0f7416)

This is a bit annoying to work around so I'm gonna go ahead and merge it :face_with_peeking_eye: 