### PR TITLE
Update EXtra-data & EXtra-geom to latest versions on CI

### DIFF
--- a/.github/dependabot/constraints.txt
+++ b/.github/dependabot/constraints.txt
@@ -1,8 +1,8 @@
-cfelpyutils==2.2.0
+cfel-fmt==2.2.0
 contourpy<=1.3.1
 cycler==0.12.1
-EXtra-data==1.20.0
-EXtra-geom==1.14.0
+EXtra-data==1.21.0
+EXtra-geom==1.15.0
 fonttools==4.58.1
 h5py==3.13.0
 karabo-bridge==0.7.0


### PR DESCRIPTION
I'm not sure why dependabot seems to have missed these. :confused: 

The dependency on cfelpyutils is replaced with `cfel-fmt`, a fork dropping the Cython parts we don't use to simplify maintenance.