### PR TITLE
[CI] Specify versions of pint & dependencies

### DIFF
--- a/.github/dependabot/constraints.txt
+++ b/.github/dependabot/constraints.txt
@@ -3,6 +3,8 @@ contourpy<=1.3.1
 cycler==0.12.1
 EXtra-data==1.21.0
 EXtra-geom==1.15.0
+flexcache==0.3
+flexparser==0.4
 fonttools==4.58.2
 h5py==3.14.0
 karabo-bridge==0.7.0
@@ -15,10 +17,13 @@ numpy<=2.2.4
 packaging==25.0
 pandas==2.3.0
 Pillow==11.2.1
+pint==0.24.4
+platformdirs~=4.3.8
 pyparsing==3.2.3
 python-dateutil==2.9.0.post0
 pytz==2025.2
 pyzmq==26.4.0
 six==1.17.0
+typing_extensions~=4.14
 tzdata==2025.2
 xarray<=2025.1.2


### PR DESCRIPTION
These are required, but not pinned, so we always get the latest. This bit us at one point (while working on #254).

Since this only affects CI, I'll merge it directly if it passes.