### PR TITLE
Fix XGM.plot_pulse_energy() to not show an extra colorbar

### DIFF
--- a/src/extra/components/xgm.py
+++ b/src/extra/components/xgm.py
@@ -358,6 +358,8 @@ class XGM:
             pulse_energy.data[pulse_energy.data == 1] = 0
             # Add units
             pulse_energy.attrs["units"] = self.instrument_source[key].units or "µJ"
+            # Set a meaningful name
+            pulse_energy.name = "Energy"
 
             self._pulse_energy[pg] = pulse_energy
 
@@ -587,12 +589,10 @@ class XGM:
         pulse_energy = self.pulse_energy(sase)
 
         from extra.utils import imshow2
-        im = imshow2(pulse_energy, ax=ax)
+        imshow2(pulse_energy, ax=ax)
 
         self._set_plot_title("XGM pulse energy heatmap", ax, sase, minimal_title)
 
-        colorbar = fig.colorbar(im)
-        colorbar.ax.set_ylabel("Energy [μJ]")
         fig.tight_layout()
 
         return ax

--- a/tests/test_components_xgm.py
+++ b/tests/test_components_xgm.py
@@ -73,22 +73,22 @@ def test_multisase_xgm(multi_xgm_run):
     # Test results without setting `default_sase`
     xgm = XGM(run, control)
     # It should automatically pick SASE 3 based on the source name
-    assert xgm.pulse_energy().name == f"{instrument}.data.intensitySa3TD"
+    assert xgm.pulse_energy().name == "Energy"
     assert xgm.pulse_counts().name == f"{control}.pulseEnergy.numberOfSa3BunchesActual"
     assert xgm.slow_train_energy().name == f"{control}.controlData.slowTrainSa3"
 
     # And with a `default_sase`
     xgm = XGM(run, control, default_sase=1)
-    assert xgm.pulse_energy().name == f"{instrument}.data.intensitySa1TD"
+    assert xgm.pulse_energy().name == "Energy"
     assert xgm.pulse_counts().name == f"{control}.pulseEnergy.numberOfSa1BunchesActual"
     assert xgm.slow_train_energy().name == f"{control}.controlData.slowTrainSa1"
 
     # Test specifying an explicit non-default SASE
-    assert xgm.pulse_energy(0).name == f"{instrument}.data.intensityTD"
+    assert xgm.pulse_energy(0).name == "Energy"
     assert xgm.pulse_counts(0).name == f"{control}.pulseEnergy.numberOfBunchesActual"
     assert xgm.slow_train_energy(0).name == f"{control}.controlData.slowTrain"
 
-    assert xgm.pulse_energy(3).name == f"{instrument}.data.intensitySa3TD"
+    assert xgm.pulse_energy(3).name == "Energy"
     assert xgm.pulse_counts(3).name == f"{control}.pulseEnergy.numberOfSa3BunchesActual"
     assert xgm.slow_train_energy(3).name == f"{control}.controlData.slowTrainSa3"
 


### PR DESCRIPTION
This fixes a bug introduced in #333:
![image](https://github.com/user-attachments/assets/4479e1a3-4017-44f5-8f29-ef4a6f977b51)

`DataArray.plot.imshow()` will automatically add a colorbar so we were accidentally adding an extra one. One way of fixing it would be to explicitly pass the colorbar label like `imshow2(pulse_energy, ax=ax, cbar_kwargs=dict(label="Energy [μJ]"))`, but I opted to change the array name instead since that feels more user-friendly/useful. Xarray will automatically set the colorbar label and pick up the unit from the `unit` attribute so there's no difference in the final label.