### PR TITLE
Ridgeplot utility function

### DIFF
--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -24,6 +24,8 @@ else.
 
 ::: extra.utils.hyperslicer2
 
+::: extra.utils.ridgeplot
+
 ## Fitting functions
 
 ::: extra.utils.fit_gaussian

--- a/src/extra/utils/misc.py
+++ b/src/extra/utils/misc.py
@@ -196,7 +196,25 @@ def hyperslicer2(arr, *args, ax=None, lognorm=False, colorbar=True, **kwargs):
     return controls
 
 
-def ridgeline_plot(data, *, overlap=0.5, xlabel=None, ylabel=None, stack_label=None, stack_ticklabels=None):
+def ridgeplot(data, *, overlap=0.5, xlabel=None, ylabel=None, stack_label=None, stack_ticklabels=None):
+    """Make a ridgeline plot showing a sequence of similar lines
+
+    A ridgeline plot spreads out the different lines vertically to make their
+    order clear, but allowing them to overlap. It's an alternative to a heatmap,
+    especially if there are relatively few rows (around 5-20).
+
+    Args:
+        data (array_like): A 2D array, each row of which will be plotted as one
+            line, starting at the top of the plot. Pass an xarray DataArray to
+            use its labels by default.
+        overlap (float): Number from 0 (no overlap) to 1, the fraction of each
+            plot's area covered by the next plot.
+        xlabel (str): Label for the shared x axis.
+        ylabel (str): Label for the y axis (drawn on the bottom plot).
+        stack_label (str): Label for the stacking axis (shown on the right)
+        stack_ticklabels (array_like): Labels for each line (shown on the right
+            next to the zero line of each plot).
+    """
     import matplotlib.pyplot as plt
     import matplotlib.gridspec as grid_spec
     from matplotlib.transforms import blended_transform_factory

--- a/src/extra/utils/misc.py
+++ b/src/extra/utils/misc.py
@@ -201,6 +201,8 @@ def ridgeline_plot(data, *, overlap=0.5, xlabel=None, ylabel=None, stack_label=N
     import matplotlib.gridspec as grid_spec
     from matplotlib.transforms import blended_transform_factory
 
+    if isinstance(data, (list, tuple)):
+        data = np.asarray(data)
     if data.ndim != 2:
         raise TypeError(f"Expected a 2D array (got {data.ndim}D)")
 
@@ -213,7 +215,7 @@ def ridgeline_plot(data, *, overlap=0.5, xlabel=None, ylabel=None, stack_label=N
         stack_label = stack_label or data.dims[0]
         if stack_ticklabels is None and data.dims[0] in data.coords:
             stack_ticklabels = data.coords[data.dims[0]].values
-    else:
+    else:  # Numpy array
         x_data = np.arange(data.shape[1])
 
     x_range = x_data.min(), x_data.max()


### PR DESCRIPTION
I can't explain this better than a screenshot:

![image](https://github.com/user-attachments/assets/edf3760f-ed61-4ac3-bfa7-eb665d85ea7a)

### When to use a ridge plot?

- vs. plotting several lines on one axis: makes the order much easier to see (e.g. delay scan steps), but precise comparison of y coordinates is harder.
- vs. plotting each line on its own axis: shows more lines on a limited space.
- vs. a heatmap: the y scale is more explicit than a colour scale (e.g. this peak is twice that one), and it leaves room for drawing extra features like error bars or vertical spans. But a heatmap can display more data.
  - In some contexts I think one type of plot may just be more readily grasped. The example above is per-pulse digitizer traces; it feels more intuitive to show these as lines, even though I don't think there's any technical reason you can't use a heatmap.

### Why not use something existing?

There are a few Python packages to do ridgeplots, but none of them seem like a great fit. In particular, because this technique is often used for comparing distributions, the default is generally to treat the input data as samples for a [KDE](https://en.wikipedia.org/wiki/Kernel_density_estimation) before plotting it, and also to fill the area under the curve. I don't think that's mostly what we want.

### Questions & limitations

- Biggest question: can the utility function cover enough use cases to be worth having?
- Additional parameters for e.g. x & y limits? If you need to modify these at present, you have to iterate through the axes.
  - It could even return a wrapper class where e.g. `.set_xlim()` works on all the axes?
- Additional parameters for visual style, like the plot colours or the presence of the grey zero lines.
- Since it uses multiple matplotlib axes, you can't pass an axes object in, which most of our plotting functions allow. Should we allow passing a figure object instead? Or is there a way to take 1 axes and split it up?
- Drawing transparent things on overlapping axes can be a bit ugly:

![image](https://github.com/user-attachments/assets/4a284d4a-72de-4db8-9f88-49cebd85d59c)
