### PR TITLE
Allow to use DataCollection object as point in time for CalibrationData

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,11 @@
     pip install git+https://github.com/European-XFEL/EXtra.git
     ```
 
+Added:
+
+- [CalibrationData.from_condition][extra.calibration.CalibrationData.from_condition] supports `DataCollection` objects to reference a point in time
+
+
 Changed:
 
 - [XGM.pulse_energy()][extra.components.XGM.pulse_energy] will now insert NaNs

--- a/src/extra/calibration.py
+++ b/src/extra/calibration.py
@@ -15,6 +15,9 @@ import pasha as psh
 import requests
 from oauth2_xfel_client import Oauth2ClientBackend
 
+from .utils.misc import _isinstance_no_import
+
+
 __all__ = [
     "CalCatAPIError",
     "CalCatAPIClient",
@@ -83,6 +86,8 @@ class CalCatAPIClient:
             return dt.astimezone(timezone.utc).isoformat()
         elif isinstance(dt, date):
             return cls.format_time(datetime.combine(dt, time()))
+        elif _isinstance_no_import(dt, 'extra_data', 'DataCollection'):
+            return cls.format_time(dt[0].train_timestamps(pydatetime=True)[0])
         elif dt is None:
             return ""  # Not specified - for searches, this usually means now
         elif not isinstance(dt, str):
@@ -588,6 +593,11 @@ class CalibrationData(Mapping):
 
         `condition` should be a conditions object for the relevant detector type,
         e.g. `DSSCConditions`.
+
+        `event_at` and `pdu_snapshot_at` should either be an ISO 8601
+        compatible string or a datetime-like object. It may also be a
+        DataCollection object from EXtra-data to use the beginning of the
+        run as a point in time.
         """
         accepted_strategies = ["closest", "prior"]
         if begin_at_strategy not in accepted_strategies:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,7 +55,7 @@ def mock_spb_aux_directory():
 
     with TemporaryDirectory() as td:
         path = Path(td) / 'RAW-R0001-DA01-S00000.h5'
-        write_file(path, sources, 100)
+        write_file(path, sources, 100, format_version='1.2')
         with h5py.File(path, 'a') as f:
             motor_ds = f['CONTROL/MOTOR/MCMOTORYFACE/actualPosition/value']
             # Simulate a scan of 10 steps, with intermediate positions for
@@ -92,7 +92,8 @@ def multi_xgm_directory():
     with TemporaryDirectory() as td:
         # We need format version 1.1 for the XGM tests, because without the full
         # run metadata we can't get RUN values after a .union() or .select().
-        write_file(Path(td) / 'RAW-R0001-DA01-S00000.h5', sources, 100, format_version="1.1")
+        write_file(Path(td) / 'RAW-R0001-DA01-S00000.h5', sources, 100,
+                   format_version="1.1")
         yield td
 
 
@@ -116,7 +117,8 @@ def mock_sqs_remi_directory():
                      data_channels={(0, 0), (2, 1)})]
 
     with TemporaryDirectory() as td:
-        write_file(Path(td) / 'RAW-R0001-DA01-S00000.h5', sources, 100)
+        write_file(Path(td) / 'RAW-R0001-DA01-S00000.h5', sources, 100,
+                   format_version='1.2')
         yield td
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,7 @@ def mock_spb_aux_directory():
         PulsePatternDecoder('TRAIN_LESS_DECODER', no_ctrl_data=True),
         Timeserver('TRAIN_LESS_TIMESERVER', no_ctrl_data=True, nsamples=0),
         Timeserver('PULSE_LESS_TIMESERVER', no_pulses=True),
-        XGM('SPB_XTD9_XGM/DOOCS/MAIN'),
+        XGM('SPB_XTD9_XGM/XGM/DOOCS'),
         Motor("MOTOR/MCMOTORYFACE"),
         DetectorMotorDataSelector("SPB_IRU_AGIPD1M/DS", "SPB_IRU_AGIPD1M"),
         DetectorMotorDataSelector("SPB_EXP_AGIPD1M2/DS", "SPB_EXP_AGIPD1M2"),
@@ -92,8 +92,8 @@ def multi_xgm_directory():
     with TemporaryDirectory() as td:
         # We need format version 1.1 for the XGM tests, because without the full
         # run metadata we can't get RUN values after a .union() or .select().
-        write_file(Path(td) / 'RAW-R0001-DA01-S00000.h5', sources, 100,
-                   format_version="1.1")
+        write_file(Path(td) / 'RAW-R0002-DA01-S00000.h5', sources, 100,
+                   format_version="1.1", firsttrain=20000)
         yield td
 
 

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 import os
 import re
 
@@ -6,6 +7,7 @@ import pytest
 import xarray as xr
 
 from extra.calibration import (
+    CalCatAPIClient,
     AGIPDConditions,
     CalibrationData,
     DSSCConditions,
@@ -235,3 +237,11 @@ def test_AGIPD_CalibrationData_report():
     assert set(agipd_cd) == {"Offset", "Noise", "ThresholdsDark", "BadPixelsDark"}
     assert agipd_cd.aggregator_names == [f"AGIPD{n:02}" for n in range(16)]
     assert isinstance(agipd_cd["Offset", "AGIPD00"], SingleConstant)
+
+
+def test_format_time(mock_spb_aux_run):
+    by_run = datetime.fromisoformat(
+        CalCatAPIClient.format_time(mock_spb_aux_run))
+
+    assert by_run.tzinfo is not None
+    assert (by_run - datetime.now(tz=by_run.tzinfo)) < timedelta(minutes=10)

--- a/tests/test_components_scan.py
+++ b/tests/test_components_scan.py
@@ -113,7 +113,7 @@ def test_scan_bin_multidimensional(mock_spb_aux_run):
 
     # Test scan binning with data with additional dimensionsn
     xgm_intensity = mock_spb_aux_run[
-        "SPB_XTD9_XGM/DOOCS/MAIN:output", "data.intensityTD"
+        "SPB_XTD9_XGM/XGM/DOOCS:output", "data.intensityTD"
     ].xarray(extra_dims=["pulse"])
 
     binned = s.bin_by_steps(xgm_intensity)

--- a/tests/test_components_xgm.py
+++ b/tests/test_components_xgm.py
@@ -111,7 +111,7 @@ def test_multisase_xgm(multi_xgm_run):
     xgm.info()
 
 def test_run_union(multi_xgm_run, mock_spb_aux_run):
-    run = multi_xgm_run.select("*SQS*").union(mock_spb_aux_run)
+    run = multi_xgm_run.select("*SPB*").union(mock_spb_aux_run)
     assert not run.is_single_run
 
     # We should be able to create the XGM object at least


### PR DESCRIPTION
It's not uncommon to look for calibration data for a particular run and one may want to take the run's beginning for the `event_at` (and `pdu_snapshot_at`) parameter. This MR adds support for this type by using the first train's timestamp.

This will also be used by a future `CalibrationData.from_data()` call.