### PR TITLE
CookieboxCalibration: Add recipe test, allow deconvolution-calibration embedding, simplify normalization

### DIFF
--- a/src/extra/recipes/cookiebox.py
+++ b/src/extra/recipes/cookiebox.py
@@ -1156,7 +1156,7 @@ class CookieboxCalibration(SerializableMixin):
 
             # integrate Auger
             mu_auger = self.tof_fit_result[tof_id].mu_auger.mean()
-            sigma = self.tof_fit_result[tof_id].sigma.min()
+            sigma = self.tof_fit_result[tof_id].sigma.max()
             auger = pulses.sel(sample=slice(int(round(mu_auger-2*sigma)), int(round(mu_auger+2*sigma)))).sum("sample")
 
             pulses = pulses.to_numpy()
@@ -1200,7 +1200,8 @@ class CookieboxCalibration(SerializableMixin):
                                         )
                             )
             if normalization == "shot":
-                o /= auger
+                o = xr.where(auger > 1.0, o/auger, 0.0)
+                np.nan_to_num(o, copy=False)
             return o
 
         outdata = [apply_correction(tof_id, trace.sel(tof=tof_id))

--- a/src/extra/recipes/cookiebox.py
+++ b/src/extra/recipes/cookiebox.py
@@ -1138,10 +1138,12 @@ class CookieboxCalibration(SerializableMixin):
             #o = np.apply_along_axis(lambda arr: np.interp(self.energy_axis, e[::-1], arr[::-1], left=0, right=0),
             #                       axis=1,
             #                       arr=pulses)
+            bad = np.isnan(pulses)
+            np.nan_to_num(pulses, copy=False)
             o = np.apply_along_axis(lambda arr: PchipInterpolator(e[::-1], arr[::-1], extrapolate=False)(self.energy_axis),
                                    axis=1,
                                    arr=pulses)
-
+            pulses[bad] = np.nan
             n_e = len(self.energy_axis)
             o = np.reshape(o, (n_t, n_p, n_e))
             # subtract offset

--- a/src/extra/recipes/cookiebox.py
+++ b/src/extra/recipes/cookiebox.py
@@ -1033,11 +1033,11 @@ class CookieboxCalibration(SerializableMixin):
         auger_start_roi = self.auger_start_roi[tof_id]
         start_roi = self.start_roi[tof_id]
         stop_roi = self.stop_roi[tof_id]
-        ts = np.arange(start_roi, stop_roi)
+        ts = np.arange(auger_start_roi, stop_roi)
         fig = plt.figure(figsize=(20,10))
         for e, c in zip(range(data.shape[0]), CSS4_COLORS.keys()):
             energy = self.calibration_energies[e]
-            plt.scatter(ts, data[e,start_roi:stop_roi], c=c, label=f"{energy:.1f} eV")
+            plt.scatter(ts, data[e,auger_start_roi:stop_roi], c=c, label=f"{energy:.1f} eV")
             mu = self.tof_fit_result[tof_id].mu[e]
             amplitude = self.tof_fit_result[tof_id].A[e]
             sigma = self.tof_fit_result[tof_id].sigma[e]
@@ -1045,6 +1045,14 @@ class CookieboxCalibration(SerializableMixin):
             gmodel = GaussianModel() + ConstantModel()
             gresult = ModelResult(gmodel, gmodel.make_params(center=mu, amplitude=amplitude, sigma=sigma, c=offset))
             plt.plot(ts, gresult.eval(x=ts), c=c, lw=2)
+
+            #auger_amplitude = self.tof_fit_result[tof_id].Aa[e]
+            #mu_auger = self.tof_fit_result[tof_id].mu_auger[e]
+            #sigma_auger = self.tof_fit_result[tof_id].sigma[e]
+            #gmodela = GaussianModel()
+            #gresulta = ModelResult(gmodela, gmodela.make_params(center=mu_auger, amplitude=auger_amplitude, sigma=sigma_auger))
+
+            #plt.plot(ts, gresulta.eval(x=ts), c=c, lw=4, ls="--")
         plt.xlabel("Samples")
         plt.ylabel("Intensty [a.u.]")
         plt.legend()

--- a/src/extra/recipes/cookiebox.py
+++ b/src/extra/recipes/cookiebox.py
@@ -391,6 +391,12 @@ class CookieboxCalibration(SerializableMixin):
         self.mask = {int(k): v for k, v in self.mask.items()}
         self.calibration_mask = {int(k): v for k, v in self.calibration_mask.items()}
         self.kwargs_adq = {int(k): v for k, v in self.kwargs_adq.items()}
+        self._tof_response = None
+        if "_tof_response" in all_data.keys():
+            self._tof_response = dict()
+            for tof_id in all_data["_tof_response"].keys():
+                self._tof_response[tof_id] = TOFAnalogResponse()
+                self._tof_response[tof_id]._fromdict(all_data["_tof_response"][tof_id])
 
     def setup(self,
               run: DataCollection,

--- a/src/extra/recipes/cookiebox.py
+++ b/src/extra/recipes/cookiebox.py
@@ -1194,7 +1194,6 @@ class CookieboxCalibration(SerializableMixin):
             outdata_corr = outdata/norm.to_numpy()[None, None, :, :]
         else:
             outdata_corr= outdata
-        print(outdata_corr)
 
         return outdata_corr
 

--- a/src/extra/recipes/cookiebox.py
+++ b/src/extra/recipes/cookiebox.py
@@ -1112,7 +1112,7 @@ class CookieboxCalibration(SerializableMixin):
 
         return outdata
 
-    def calibrate(self, trace: xr.DataArray, normalization: str="shot", subtract_offset: bool=False) -> xr.DataArray:
+    def calibrate(self, trace: xr.DataArray, normalization: str="average", subtract_offset: bool=False) -> xr.DataArray:
         """
         Takes a trace separated with axes ('trainId', 'pulseIndex', 'sample', 'tof'),
         as given by `load_trace` and applies the calibration.
@@ -1124,7 +1124,7 @@ class CookieboxCalibration(SerializableMixin):
           trace: A pre-processed trace retrieved with the *same* `AdqRawChannel` settings as this calibration object.
                  Its axes are expected to be ('trainId', 'pulseIndex', 'sample', 'tof').
                  It is recommended to use always `load_trace` to obtain this.
-          normalization: If "shot", nrmalize by the Auger peak, if "average", use the average transmission.
+          normalization: If "shot", normalize by the Auger peak, if "average", use the average transmission.
           subtract_offset: Whether to subtract a offset.
 
         Returns: the calibrated data as an xarray DataArray.

--- a/src/extra/recipes/cookiebox.py
+++ b/src/extra/recipes/cookiebox.py
@@ -1095,9 +1095,9 @@ class CookieboxCalibration(SerializableMixin):
             pulses = tof.pulse_data(pulse_dim='pulseIndex').unstack('pulse').transpose('trainId', 'pulseIndex', 'sample')
             pulses = -pulses.isel(sample=slice(start_roi, stop_roi))
             if self._tof_response is not None:
-                pulses = pulses.stack(pulse=("trainId", "pulseIndex"))
+                pulses = pulses.stack(pulse=("trainId", "pulseIndex")).transpose('pulse', 'sample')
                 pulses = self._tof_response[tof_id].apply(pulses.fillna(0.0), **kwargs_response)
-                pulses = pulses.unstack("pulse")
+                pulses = pulses.unstack("pulse").transpose('trainId', 'pulseIndex', 'sample')
             return pulses
 
         outdata = [fetch(tof_id)

--- a/src/extra/recipes/cookiebox.py
+++ b/src/extra/recipes/cookiebox.py
@@ -369,6 +369,7 @@ class CookieboxCalibration(SerializableMixin):
                             "calibration_mask",
                             #"sources",
                             "calibration_energies",
+                            "_tof_response",
                             "_version",
                            ]
     def _asdict(self):


### PR DESCRIPTION
As promised, a test has been added to test changes in the CookieboxCalibration code, using an existing commissioning run (and therefore this requires GPFS, so it runs only if GPFS is available. That should be triggered in https://git.xfel.eu/dataAnalysis/extra-tests

In addition, previous code required some manual alignment if one wanted to use the `TOFAnalogResponse` and the `CookieboxCalibration`. Now, if one provides a dictionary of `TOFAnalogResponse` objects in the `setup` of `CookieboxCalibration`, this alignment is not needed, as the calibration fit is done on the deconvolved data directly (although this is slower -- still, it is the correct thing to do).

The normalization code has also been simplified to contain only the `normalization` factor (the other was not needed).

Finally, since the `_tof_response` variable may be `None`, depending or not on whether this is desired, the base class used for persistence has been adapted to cope with it.