### PR TITLE
Add Calibration.from_data()

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,11 +22,15 @@ Added:
   [AdqRawChannel.train_data][extra.components.AdqRawChannel.pulse_data] are now
   reading data in parallel by default (!497).
 - [AGIPDConditions][extra.calibration.AGIPDConditions] now recognizes current source constant types
+- [CalibrationData.from_data][extra.calibration.CalibrationData.from_data] method to
+  find the constants suitable for a given `DataCollection`
 - [DetectorData][extra.calibration.DetectorData] to obtain detector metadata and
   module mapping from the Calibration Cataloge (!408).
 - [SpectrometerCalibration][extra.gui.jupyter.SpectrometerCalibration] to
   provide a Jupyter widget for energy calibration of 2D X-ray spectrum data
   (!363).
+- Pre-built packages will be available on PyPI for Python 3.10 - 3.13 from the
+  next release, rather than only Python 3.10 (!377).
 - [CalibrationData.from_condition][extra.calibration.CalibrationData.from_condition]
   supports `DataCollection` objects to reference a point in time
 - [CalibrationData.from_correction][extra.calibration.CalibrationData.from_correction]
@@ -37,8 +41,6 @@ Added:
 - [lpd_dark_consts_with_fallback][extra.calibration.lpd_dark_consts_with_fallback]
   function to find LPD dark constants with a fallback to constants recorded with
   all memory cells.
-- Pre-built packages will be available on PyPI for Python 3.10 - 3.13 from the
-  next release, rather than only Python 3.10 (!377).
 - [Scan.group_data()][extra.components.Scan.group_data] method to make an xarray
   or pandas GroupBy object based on scan steps (!379).
 - [Scan.from_motor_targets()][extra.components.Scan.from_motor_targets] method

--- a/src/extra/calibration.py
+++ b/src/extra/calibration.py
@@ -1508,18 +1508,16 @@ class AGIPDConditions(ConditionsBase):
     def bias_voltage_from_control(sd):
         # These device used to suffer from switching to excessive values
         # randomly, so cut off any unreasonable values.
-        values = sd['highVoltage.actual'].ndarray()
+        values = sd['highVoltage.target'].ndarray()
         values = values[values < 1000.0]
         return int(np.median(values))
 
     @staticmethod
     def bias_voltage_from_mpod(sd, modules=None):
         if modules is not None:
-            keys = [f'channels.U{modno}.measurementSenseVoltage'
-                    for modno in modules]
+            keys = [f'channels.U{modno}.voltage' for modno in modules]
         else:
-            keys = sd.select_keys(
-                'channels.U*.measurementSenseVoltage').keys(False)
+            keys = sd.select_keys('channels.U*.voltage').keys(False)
 
         for key in keys:
             if (val := sd[key].as_single_value(atol=1, rtol=1)) > 0:

--- a/src/extra/calibration.py
+++ b/src/extra/calibration.py
@@ -1369,7 +1369,7 @@ class AGIPDConditions(ConditionsBase):
     acquisition_rate: float
     gain_setting: Optional[int]
     gain_mode: Optional[int]
-    source_energy: float
+    source_energy: float = 9.2
     integration_time: int = 12
     pixels_x: int = 512
     pixels_y: int = 128

--- a/src/extra/calibration.py
+++ b/src/extra/calibration.py
@@ -2,8 +2,9 @@
 import ast
 import json
 import re
-from collections.abc import Mapping
-from dataclasses import dataclass, field, fields, replace
+from collections.abc import Mapping, Iterable
+from dataclasses import (
+    dataclass, field, fields, replace, is_dataclass, MISSING)
 from datetime import date, datetime, time, timedelta, timezone
 from enum import IntFlag
 from fnmatch import fnmatch
@@ -21,6 +22,8 @@ import pasha as psh
 import requests
 from extra_data.read_machinery import find_proposal
 from oauth2_xfel_client import Oauth2ClientBackend
+
+from extra_data import PropertyNameError
 
 from .utils.misc import _isinstance_no_import
 
@@ -44,6 +47,14 @@ __all__ = [
 CALCAT_PROXY_URL = "http://exflcalproxy.desy.de:8080/"
 
 
+def any_is_none(*values):
+    for value in values:
+        if value is None:
+            return True
+
+    return False
+
+
 class ModuleNameError(KeyError):
     def __init__(self, name):
         self.name = name
@@ -52,9 +63,38 @@ class ModuleNameError(KeyError):
         return f"No module named {self.name!r}"
 
 
-
 class NoDimensionLabelsError(ValueError):
     pass
+
+
+class AutoConditionsError(ValueError):
+    """Used when detector conditions could not be inferred from data."""
+
+    def __init__(self, missing, sources):
+        self.missing = missing
+        self.sources = sources
+
+    def __str__(self):
+        msg = 'required parameters could not be inferred from data: ' + \
+            ', '.join(sorted(self.missing))
+
+        if self.sources:
+            msg += '\n\navailable sources to infer parameters:\n'
+
+            for name, value in self.sources.items():
+                if isinstance(value, Iterable) and not isinstance(value, str):
+                    if len(value) > 1:
+                        value = f'{sorted(value)[0]}, ...[{len(value) - 1} more]'
+
+                    elif len(value) == 1:
+                        value = str(next(iter(value)))
+
+                    elif not value:
+                        value = None
+
+                msg += f'- {name}: {value}\n'
+
+        return msg
 
 
 class CalCatAPIError(requests.HTTPError):
@@ -1232,13 +1272,19 @@ class CalibrationData(Mapping):
 class ConditionsBase:
     calibration_types = {}  # For subclasses: {calibration: [parameter names]}
 
-    def _repr_markdown_(self):
-        attr_names = [f.name for f in fields(self)]
-        items = []
-        for n in attr_names:
-            if (value := getattr(self, n)) is not None:
-                items.append(f"- {n.replace('_', ' ').capitalize()}: {value}")
-        return '\n'.join(items)
+    @classmethod
+    def from_data(cls, params, **sources):
+        if is_dataclass(cls):
+            # Try to give a nicer error message if the conditions type
+            # is a dataclass.
+            required_fields = {f.name for f in fields(cls) if
+                               bool(f.init and f.default is MISSING and
+                                    f.default_factory is MISSING)}
+
+            if (missing := required_fields - params.keys()):
+                raise AutoConditionsError(missing, sources)
+
+        return cls(**params)
 
     def make_dict(self, parameters) -> dict:
         d = dict()
@@ -1251,6 +1297,40 @@ class ConditionsBase:
                 d[db_name] = float(value)
 
         return d
+
+    def _repr_markdown_(self):
+        attr_names = [f.name for f in fields(self)]
+        items = []
+        for n in attr_names:
+            if (value := getattr(self, n)) is not None:
+                items.append(f"- {n.replace('_', ' ').capitalize()}: {value}")
+        return '\n'.join(items)
+
+    @staticmethod
+    def _find_detector_modules(data, det):
+        assert det['first_module_index'] is not None and \
+            det['number_of_modules'] is not None, \
+            'incomplete detector entry in CalCat'
+
+        # Find module numbers present in data.
+        return {
+            modno for modno in range(
+                det['first_module_index'],
+                det['first_module_index'] + det['number_of_modules'])
+            if det['source_name_pattern'].format(modno=modno)
+                in data.instrument_sources}
+
+    @staticmethod
+    def _purge_missing_sources(data, *sources):
+        result = []
+
+        for src in sources:
+            if isinstance(src, str):
+                result.append(src if src in data.all_sources else None)
+            else:
+                result.append([s for s in src if s in data.all_sources])
+
+        return result
 
 
 @dataclass
@@ -1303,6 +1383,173 @@ class AGIPDConditions(ConditionsBase):
             del cond["Integration time"]
 
         return cond
+
+    @classmethod
+    def from_data(cls, data, detector,
+                  fpga_comp=None, mpod=None, fpga_control=None, xtdf=None,
+                  client=None, **params):
+        # Uncaught exceptions that may be thrown in here:
+        # - NoDataError
+
+        if any_is_none(fpga_comp, mpod, fpga_control, xtdf):
+            if not isinstance(detector, DetectorData):
+                detector = DetectorData.from_identifier(
+                    detector, pdu_snapshot_at=data, client=client)
+
+            control_domain = detector.karabo_control_domain
+
+            fpga_comp = fpga_comp or f'{control_domain}/MDL/FPGA_COMP'
+            mpod = mpod or f'{control_domain[:-1]}/PSC/HV'
+
+            if xtdf is None:
+                xtdf = detector.source_names
+
+            if fpga_control is None:
+                fpga_control = [f'{control_domain}/FPGA/M_{i}'
+                                for i in range(len(xtdf))]
+
+        fpga_comp, mpod, fpga_control, xtdf = cls._purge_missing_sources(
+            data, fpga_comp, mpod, fpga_control, xtdf)
+
+        if fpga_comp is not None:
+            # Prefer control data from FPGA composite device.
+            sd = data[fpga_comp]
+
+            if 'memory_cells' not in params:
+                params['memory_cells'] = cls.memory_cells_from_comp(sd)
+
+            if 'acquisition_rate' not in params:
+                try:
+                    val = cls.acquisition_rate_from_comp(sd)
+                except PropertyNameError:
+                    pass  # Not present in older data
+                else:
+                    params['acquisition_rate'] = val
+
+            if 'gain_setting' not in params:
+                params['gain_setting'] = cls.gain_setting_from_comp(sd)
+
+            if 'gain_mode' not in params:
+                params['gain_mode'] = cls.gain_mode_from_comp(sd)
+
+            if 'integration_time' not in params:
+                try:
+                    val = cls.integration_time_from_comp(sd)
+                except PropertyNameError:
+                    # More recent feature of comp device, fallback to
+                    # prior defalt.
+                    val = 12
+
+                params['integration_time'] = val
+
+        if xtdf:
+            # Fallback to estimate some parameters from XTDF data.
+            if 'memory_cells' not in params:
+                for src in xtdf:
+                    if (val := cls.memory_cells_from_xtdf(data[src])) > 0:
+                        break
+
+                params['memory_cells'] = val
+
+            if 'acquisition_rate' not in params:
+                for src in xtdf:
+                    if (val := cls.acquisition_rate_from_xtdf(data[src])) > 0:
+                        break
+
+                params['acquisition_rate'] = val
+
+        if 'sensor_bias_voltage' not in params:
+            if mpod is not None:
+                # AGIPD Gen1
+                params['sensor_bias_voltage'] = cls.bias_voltage_from_mpod(
+                    data[mpod])
+
+            elif fpga_control:
+                # AGIPD Gen2
+                for src in fpga_control:
+                    if (val := cls.bias_voltage_from_control(data[src])) > 0:
+                        break
+
+                params['sensor_bias_voltage'] = val
+
+        return super().from_data(params,
+                                 fpga_comp=fpga_comp, mpod=mpod,
+                                 fpga_control=fpga_control, xtdf=xtdf)
+
+    @staticmethod
+    def bias_voltage_from_control(sd):
+        # These device used to suffer from switching to excessive values
+        # randomly, so cut off any unreasonable values.
+        values = sd['highVoltage.actual'].ndarray()
+        values = values[values < 1000.0]
+        return int(np.median(values))
+
+    @staticmethod
+    def bias_voltage_from_mpod(sd, modules=None):
+        if modules is not None:
+            keys = [f'channels.U{modno}.measurementSenseVoltage'
+                    for modno in modules]
+        else:
+            keys = sd.select_keys(
+                'channels.U*.measurementSenseVoltage').keys(False)
+
+        for key in keys:
+            if (val := sd[key].as_single_value(atol=1, rtol=1)) > 0:
+                return int(val)
+        else:
+            return 0  # All modules are powered off.
+
+    @staticmethod
+    def memory_cells_from_comp(sd):
+        return int(sd['bunchStructure.nPulses']
+            .as_single_value(reduce_by='max'))
+
+    @staticmethod
+    def memory_cells_from_xtdf(sd):
+        # Only look at one train?
+        cell_ids = sd['image.cellId'].drop_empty_trains().ndarray().squeeze()
+        options = np.array([4, 32, 64, 76, 128, 176, 202, 250, 352])
+        return int(options[np.flatnonzero(options > np.max(cell_ids)).min()])
+
+    @staticmethod
+    def acquisition_rate_from_comp(sd):
+        return round(float(sd['bunchStructure.repetitionRate']
+            .as_single_value()), 1)
+
+    @staticmethod
+    def acquisition_rate_from_xtdf(sd):
+        pulse_ids = sd['image.pulseId'].drop_empty_trains().ndarray().squeeze()
+        return round(np.floor(45 / np.diff(pulse_ids).min()) / 10, 1)
+
+    @staticmethod
+    def gain_setting_from_comp(sd):
+        if 'gain' in sd:
+            return int(sd['gain'].as_single_value(atol=0))
+
+        # Legacy method for older versions of composite device.
+
+        setupr = sd['setupr'].as_single_value()
+        pattern_type_idx = sd['patternTypeIndex'].as_single_value()
+
+        if (setupr == 0 and pattern_type_idx < 4):
+            return 0
+        elif (setupr == 32 and pattern_type_idx == 4):
+            return 0
+        elif (setupr == 8 and pattern_type_idx < 4):
+            return 1
+        elif (setupr == 40 and pattern_type_idx == 4):
+            return 1
+
+        raise ValueError('unexpected setupr and patternTypeIndex values to '
+                         'determine CDS mode')
+
+    @staticmethod
+    def gain_mode_from_comp(sd):
+        return int(sd['gainModeIndex'].as_single_value(atol=0))
+
+    @staticmethod
+    def integration_time_from_comp(sd):
+        return int(sd['integrationTime'].as_single_value())
 
 
 @dataclass

--- a/src/extra/calibration.py
+++ b/src/extra/calibration.py
@@ -1596,6 +1596,71 @@ class LPDConditions(ConditionsBase):
 
         return cond
 
+    @classmethod
+    def from_data(cls, data, detector, fem_comp=None, xtdf=None,
+                  validate_memcell_order=False, use_memcell_order='auto',
+                  client=None, **params):
+        if any_is_none(fem_comp, xtdf):
+            if not isinstance(detector, DetectorData):
+                detector = DetectorData.from_identifier(
+                    detector, pdu_snapshot_at=data, client=client)
+
+            fem_comp = fem_comp or (
+                detector.karabo_control_domain + '/COMP/FEM_MDL_COMP')
+
+            if xtdf is None:
+                xtdf = data.instrument_sources.intersection(
+                    detector.source_names)
+
+        fem_comp, xtdf = cls._purge_missing_sources(data, fem_comp, xtdf)
+
+        if fem_comp is not None and 'parallel_gain' not in params:
+            try:
+                val = cls.parallel_gain_from_fem_comp(data[fem_comp])
+            except PropertyNameError:
+                # Added to the FEM comp with introduction of parallel
+                # gain support.
+                val = False
+
+            params['parallel_gain'] = val
+
+        if xtdf and 'memory_cell_order' not in params:
+            prev_val = None  # used with validate_memory_order
+
+            for src in xtdf:
+                if (val := cls.memory_cell_order_from_xtdf(data[src])).size:
+                    if validate_memcell_order:
+                        if prev_val is not None and (prev_val != val).any():
+                            raise ValueError('inconsistent memory order '
+                                             'across modules')
+
+                        prev_val = val
+                    else:
+                        break
+
+            if use_memcell_order == 'auto':
+                use = len(val) > 2 and (np.diff(val.astype(np.int32)) < 0).any()
+            else:
+                use = use_memcell_order == 'always'
+
+            params['memory_cell_order'] = '{},'.format(
+                ','.join([str(c) for c in val])) if use else None
+
+        return super().from_data(params, fem_comp=fem_comp, xtdf=xtdf)
+
+    @staticmethod
+    def gain_mode_from_fem_comp(sd):
+        # Not actually used in the condition at the moment.
+        return int(sd.run_value('femAsicGain'))
+
+    @staticmethod
+    def parallel_gain_from_fem_comp(sd):
+        return bool(sd.run_value('femAsicGainOverride'))
+
+    @staticmethod
+    def memory_cell_order_from_xtdf(sd):
+        return sd['image.cellId'].drop_empty_trains()[0].ndarray().flatten()
+
 
 def lpd_dark_consts_with_fallback(
     condition: "LPDConditions",

--- a/src/extra/calibration.py
+++ b/src/extra/calibration.py
@@ -686,10 +686,11 @@ class CalibrationData(Mapping):
     (e.g. `cd["Offset"]`), giving you `MultiModuleConstant` objects.
     """
 
-    def __init__(self, constant_groups, detector):
+    def __init__(self, constant_groups, detector, condition=None):
         # {calibration: {karabo_da: SingleConstant}}
         self.constant_groups = constant_groups
         self.detector = detector
+        self._condition = condition
 
     @staticmethod
     def _format_cond(condition):
@@ -785,7 +786,7 @@ class CalibrationData(Mapping):
                 const_group = constant_groups.setdefault(cal_type, {})
                 const_group[aggr] = SingleConstant.from_response(ccv)
 
-        return cls(constant_groups, detector)
+        return cls(constant_groups, detector, condition)
 
     @classmethod
     def from_report(
@@ -991,6 +992,47 @@ class CalibrationData(Mapping):
             pdu["detector_type"] = detector_types[pdu["detector_type_id"]]
 
         return cls(constant_groups, DetectorData(detector_row, pdus.values()))
+
+    @classmethod
+    def from_data(
+            cls,
+            data: 'DataCollection',
+            detector_name: str,
+            calibrations=None,
+            client=None,
+            begin_at_strategy='closest',
+            **kwargs
+    ):
+        """Look up constants applicable to given a dataset.
+
+        `data` should be an EXtra-data `DataCollection` object containing
+        the necessary metadata to identify the detector conditions.
+        `detector_name` refers to the detector identifer as used in CalCat,
+        typically identical to its Karabo domain, i.e. the first part of
+        its device IDs.
+
+        The remaining arguments behave in the same way as for
+        `CalibrationData.from_condition` and any additional keyword
+        arguments are passed on to the applicable `ConditionsBase.from_data`
+        method, e.g. `AGIPDConditions.from_data`.
+        """
+
+        creation_date = data[0].train_timestamps(pydatetime=True)[0]
+
+        client = client or get_client()
+        det = DetectorData.from_identifier(detector_name, client=client,
+                                           pdu_snapshot_at=creation_date)
+
+        try:
+            cond_cls = detector_cond_cls[det.detector_type]
+        except KeyError:
+            raise NotImplementedError(det.detector_type)
+
+        return cls.from_condition(
+            cond_cls.from_data(data, detector_name, client=client, **kwargs),
+            detector_name, calibrations=calibrations, client=client,
+            event_at=creation_date, pdu_snapshot_at=creation_date,
+            begin_at_strategy=begin_at_strategy)
 
     def __getitem__(self, key):
         if isinstance(key, str):
@@ -1305,20 +1347,6 @@ class ConditionsBase:
             if (value := getattr(self, n)) is not None:
                 items.append(f"- {n.replace('_', ' ').capitalize()}: {value}")
         return '\n'.join(items)
-
-    @staticmethod
-    def _find_detector_modules(data, det):
-        assert det['first_module_index'] is not None and \
-            det['number_of_modules'] is not None, \
-            'incomplete detector entry in CalCat'
-
-        # Find module numbers present in data.
-        return {
-            modno for modno in range(
-                det['first_module_index'],
-                det['first_module_index'] + det['number_of_modules'])
-            if det['source_name_pattern'].format(modno=modno)
-                in data.instrument_sources}
 
     @staticmethod
     def _purge_missing_sources(data, *sources):
@@ -2202,6 +2230,13 @@ class DetectorData(Mapping):
             raise ValueError('no mapped PDUs')
 
         return pdu_types.pop()
+
+
+detector_cond_cls = {
+    'AGIPD-Type': AGIPDConditions,
+    'LPD-Type': LPDConditions,
+    'jungfrau-Type': JUNGFRAUConditions
+}
 
 
 class BadPixels(IntFlag):

--- a/src/extra/calibration.py
+++ b/src/extra/calibration.py
@@ -1785,6 +1785,33 @@ class JUNGFRAUConditions(ConditionsBase):
         "BadPixelsFF10Hz": _params,
     }
 
+    # Before 2022, the settings key indicated both gain
+    # mode (as in adaptive vs fixed gain) as well as gain
+    # setting (as in high CDS or not). Since then, there
+    # is a dedicated gainMode key and settings only
+    # indicates high CDS.
+    # See karaboDevices/slsDetectors@4433ae9c00edcca3309bec8b7515e0938f5f502c
+    legacy_settings = {
+        # old setting:  new settings, new gainMode
+        'dynamicgain': ('gain0', 'dynamic'),
+        'dynamichg0':  ('highgain0', 'dynamic'),
+        'fixgain1': ('gain0', 'fixg1'),
+        'fixgain2': ('gain0', 'fixg2'),
+        'forceswitchg1': ('gain0', 'forceswitchg1'),
+        'forceswitchg2': ('gain0', 'forceswitchg2'),
+    }
+
+    gain_mode_labels = {
+        'dynamic': 0,
+        'fixg0': 1,
+        'fixg1': 2,
+        'fixg2': 3,
+
+        # forceswitchg1, forceswitchg2 may only be used for
+        # darks and are not equivalent to their fixed gain
+        # equivalents.
+    }
+
     def make_dict(self, parameters):
         cond = super().make_dict(parameters)
 
@@ -1797,6 +1824,95 @@ class JUNGFRAUConditions(ConditionsBase):
             del cond["Exposure timeout"]
 
         return cond
+
+    @classmethod
+    def from_data(cls, data, detector, control=None, client=None, **params):
+        if control is None:
+            detector = DetectorData.from_identifier(detector, client=client,
+                                                    pdu_snapshot_at=data)
+
+            control = control or '{}/DET/CONTROL'.format(
+                detector.karabo_control_domain)
+
+        control, = cls._purge_missing_sources(data, control)
+
+        if control is not None:
+            sd = data[control]
+
+            if 'sensor_bias_voltage' not in params:
+                params['sensor_bias_voltage'] = cls.sensor_bias_voltage_from_control(sd)
+
+            if 'memory_cells' not in params:
+                params['memory_cells'] = cls.memory_cells_from_control(sd)
+
+            if 'integration_time' not in params:
+                params['integration_time'] = cls.integration_time_from_control(sd)
+
+            if 'exposure_timeout' not in params:
+                params['exposure_timeout'] = cls.exposure_timeout_from_control(sd)
+
+            if 'gain_setting' not in params:
+                params['gain_setting'] = cls.gain_setting_from_control(sd)
+
+            if 'gain_mode' not in params:
+                params['gain_mode'] = cls.gain_mode_from_control(sd)
+
+        return super().from_data(params, control=control)
+
+    @staticmethod
+    def sensor_bias_voltage_from_control(sd):
+        for key in ['highVoltage', 'vHighVoltage']:
+            if key not in sd:
+                continue
+
+            return int(sd.run_value(key)[0])
+
+        raise PropertyNameError('highVoltage or vHighVoltage', sd.source)
+
+    @staticmethod
+    def memory_cells_from_control(sd):
+        return int(sd.run_value('storageCells')) + 1
+
+    @staticmethod
+    def memory_cell_start_from_control(sd):
+        # Not used in condition, but relevant for dark characterization.
+        return int(sd.run_value('storageCellStart'))
+
+    @staticmethod
+    def integration_time_from_control(sd):
+        return 1e6 * float(sd.run_value('exposureTime'))
+
+    @staticmethod
+    def exposure_timeout_from_control(sd):
+        return int(sd.run_value('exposureTimeout'))
+
+    @classmethod
+    def gain_setting_from_control(cls, sd, raw=False):
+        val = sd.run_value('settings')
+
+        if 'gainMode' not in sd:
+            # Convert from legacy value.
+            val = cls.legacy_settings[val][0]
+
+        if raw:
+            return val
+
+        return int(val == 'highgain0')
+
+    @classmethod
+    def gain_mode_from_control(cls, sd, raw=False):
+        try:
+            val = sd.run_value('gainMode')
+        except PropertyNameError:
+            val = cls.legacy_settings[sd.run_value('settings')][1]
+
+        if raw:
+            return val
+
+        try:
+            return cls.gain_mode_labels[val]
+        except KeyError:
+            raise ValueError(f'invalid gain mode {val!s} encountered') from None
 
 
 @dataclass

--- a/tests/cassettes/test_calibration/test_AGIPDConditions_from_data.yaml
+++ b/tests/cassettes/test_calibration/test_AGIPDConditions_from_data.yaml
@@ -1,0 +1,508 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json; version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - EXtra/2025.1.194+7868e3e
+      content-type:
+      - application/json
+    method: GET
+    uri: http://exflcalproxy.desy.de:8080/api/me
+  response:
+    body:
+      string: '{"id":-9,"email":"admin@example.com","provider":"local","contact_email":"admin@example.com","name":"Admin
+        User","first_name":"Admin","last_name":"User","nickname":null,"uid":null,"ldap_synced_at":null,"flg_service_account":true,"flg_ldap_account_valid":false,"roles":["admin"]}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '277'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 10 Apr 2026 10:14:14 GMT
+      Etag:
+      - W/"9ec4cec974b56aebafbb6dc312056934"
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=16070400; includeSubDomains
+      Vary:
+      - Origin
+      Via:
+      - HTTP/1.1 xfel_oauth_proxy
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R)
+      X-Request-Id:
+      - f0086b34-019c-498f-a3f1-b29aa7a1800e
+      X-Runtime:
+      - '0.027269'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json; version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - EXtra/2025.1.194+7868e3e
+      content-type:
+      - application/json
+    method: GET
+    uri: http://exflcalproxy.desy.de:8080/api/detectors?identifier=SPB_DET_AGIPD1M-1
+  response:
+    body:
+      string: '[{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null,"detectors_instruments":[{"instrument_id":3,"detector_id":2},{"instrument_id":7,"detector_id":2}]}]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '389'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 10 Apr 2026 10:14:14 GMT
+      Etag:
+      - W/"73d84e307238475d3943984c03827c80"
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=16070400; includeSubDomains
+      Vary:
+      - Origin
+      Via:
+      - HTTP/1.1 xfel_oauth_proxy
+      X-Content-Type-Options:
+      - nosniff
+      X-Count-Per-Page:
+      - '100'
+      X-Current-Page:
+      - '1'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R)
+      X-Request-Id:
+      - 5e8af911-6643-4216-80af-98ed4a2dd22c
+      X-Runtime:
+      - '0.026113'
+      X-Total-Count:
+      - '1'
+      X-Total-Pages:
+      - '1'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json; version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - EXtra/2025.1.194+7868e3e
+      content-type:
+      - application/json
+    method: GET
+    uri: http://exflcalproxy.desy.de:8080/api/physical_detector_units/get_all_by_detector?detector_id=2&pdu_snapshot_at=2026-04-10T11%3A27%3A00%2B00%3A00
+  response:
+    body:
+      string: '[{"id":188,"physical_name":"AGIPD_SIV1_AGIPDV11_M517","karabo_da":"AGIPD00","virtual_device_name":"Q1M1","uuid":101003000000,"float_uuid":4.9902112427e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":218,"physical_name":"AGIPD_SIV1_AGIPDV12_M421","karabo_da":"AGIPD01","virtual_device_name":"Q1M2","uuid":102013100004,"float_uuid":5.04011681377e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":219,"physical_name":"AGIPD_SIV1_AGIPDV12_M445","karabo_da":"AGIPD02","virtual_device_name":"Q1M3","uuid":102023100004,"float_uuid":5.0406108794e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":287,"physical_name":"AGIPD_SIV1_AGIPDV12_M447","karabo_da":"AGIPD03","virtual_device_name":"Q1M4","uuid":102033100010,"float_uuid":5.04110494536e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":"This
+        is a new module installed on 19.06.2025 on position Q1M4","detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":223,"physical_name":"AGIPD_SIV1_AGIPDV12_M410","karabo_da":"AGIPD04","virtual_device_name":"Q2M1","uuid":102063100000,"float_uuid":5.0425871418e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":224,"physical_name":"AGIPD_SIV1_AGIPDV12_M528","karabo_da":"AGIPD05","virtual_device_name":"Q2M2","uuid":102073100000,"float_uuid":5.04308120745e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":248,"physical_name":"AGIPD_SIV1_AGIPDV12_M425","karabo_da":"AGIPD06","virtual_device_name":"Q2M3","uuid":102053100001,"float_uuid":5.0420930762e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":288,"physical_name":"AGIPD_SIV1_AGIPDV12_M411","karabo_da":"AGIPD07","virtual_device_name":"Q2M4","uuid":102033100020,"float_uuid":5.04110494586e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":"This
+        is a new module installed on 19.06.2025 on position Q2M4","detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":225,"physical_name":"AGIPD_SIV1_AGIPDV12_M412","karabo_da":"AGIPD08","virtual_device_name":"Q3M1","uuid":102083100000,"float_uuid":5.0435752731e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":226,"physical_name":"AGIPD_SIV1_AGIPDV12_M542","karabo_da":"AGIPD09","virtual_device_name":"Q3M2","uuid":102093100000,"float_uuid":5.04406933874e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":227,"physical_name":"AGIPD_SIV1_AGIPDV12_M527","karabo_da":"AGIPD10","virtual_device_name":"Q3M3","uuid":102103100000,"float_uuid":5.0445634044e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":228,"physical_name":"AGIPD_SIV1_AGIPDV12_M502","karabo_da":"AGIPD11","virtual_device_name":"Q3M4","uuid":102113100000,"float_uuid":5.04505747004e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":229,"physical_name":"AGIPD_SIV1_AGIPDV12_M426","karabo_da":"AGIPD12","virtual_device_name":"Q4M1","uuid":102123100000,"float_uuid":5.0455515357e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":230,"physical_name":"AGIPD_SIV1_AGIPDV12_M540","karabo_da":"AGIPD13","virtual_device_name":"Q4M2","uuid":102133100000,"float_uuid":5.04604560133e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":231,"physical_name":"AGIPD_SIV1_AGIPDV12_M515","karabo_da":"AGIPD14","virtual_device_name":"Q4M3","uuid":102143100000,"float_uuid":5.04653966697e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":232,"physical_name":"AGIPD_SIV1_AGIPDV12_M544","karabo_da":"AGIPD15","virtual_device_name":"Q4M4","uuid":102153100000,"float_uuid":5.0470337326e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}}]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '10575'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 10 Apr 2026 10:14:14 GMT
+      Etag:
+      - W/"ba18dd44f59a27e5b90cd68a88820653"
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=16070400; includeSubDomains
+      Vary:
+      - Origin
+      Via:
+      - HTTP/1.1 xfel_oauth_proxy
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R)
+      X-Request-Id:
+      - 2fa9c521-7f72-49db-bad9-1c17e7a6fec9
+      X-Runtime:
+      - '0.539096'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json; version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - EXtra/2025.1.194+7868e3e
+      content-type:
+      - application/json
+    method: GET
+    uri: http://exflcalproxy.desy.de:8080/api/physical_detector_units/get_all_by_detector?detector_id=2&pdu_snapshot_at=2026-04-10T11%3A27%3A00%2B00%3A00
+  response:
+    body:
+      string: '[{"id":188,"physical_name":"AGIPD_SIV1_AGIPDV11_M517","karabo_da":"AGIPD00","virtual_device_name":"Q1M1","uuid":101003000000,"float_uuid":4.9902112427e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":218,"physical_name":"AGIPD_SIV1_AGIPDV12_M421","karabo_da":"AGIPD01","virtual_device_name":"Q1M2","uuid":102013100004,"float_uuid":5.04011681377e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":219,"physical_name":"AGIPD_SIV1_AGIPDV12_M445","karabo_da":"AGIPD02","virtual_device_name":"Q1M3","uuid":102023100004,"float_uuid":5.0406108794e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":287,"physical_name":"AGIPD_SIV1_AGIPDV12_M447","karabo_da":"AGIPD03","virtual_device_name":"Q1M4","uuid":102033100010,"float_uuid":5.04110494536e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":"This
+        is a new module installed on 19.06.2025 on position Q1M4","detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":223,"physical_name":"AGIPD_SIV1_AGIPDV12_M410","karabo_da":"AGIPD04","virtual_device_name":"Q2M1","uuid":102063100000,"float_uuid":5.0425871418e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":224,"physical_name":"AGIPD_SIV1_AGIPDV12_M528","karabo_da":"AGIPD05","virtual_device_name":"Q2M2","uuid":102073100000,"float_uuid":5.04308120745e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":248,"physical_name":"AGIPD_SIV1_AGIPDV12_M425","karabo_da":"AGIPD06","virtual_device_name":"Q2M3","uuid":102053100001,"float_uuid":5.0420930762e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":288,"physical_name":"AGIPD_SIV1_AGIPDV12_M411","karabo_da":"AGIPD07","virtual_device_name":"Q2M4","uuid":102033100020,"float_uuid":5.04110494586e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":"This
+        is a new module installed on 19.06.2025 on position Q2M4","detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":225,"physical_name":"AGIPD_SIV1_AGIPDV12_M412","karabo_da":"AGIPD08","virtual_device_name":"Q3M1","uuid":102083100000,"float_uuid":5.0435752731e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":226,"physical_name":"AGIPD_SIV1_AGIPDV12_M542","karabo_da":"AGIPD09","virtual_device_name":"Q3M2","uuid":102093100000,"float_uuid":5.04406933874e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":227,"physical_name":"AGIPD_SIV1_AGIPDV12_M527","karabo_da":"AGIPD10","virtual_device_name":"Q3M3","uuid":102103100000,"float_uuid":5.0445634044e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":228,"physical_name":"AGIPD_SIV1_AGIPDV12_M502","karabo_da":"AGIPD11","virtual_device_name":"Q3M4","uuid":102113100000,"float_uuid":5.04505747004e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":229,"physical_name":"AGIPD_SIV1_AGIPDV12_M426","karabo_da":"AGIPD12","virtual_device_name":"Q4M1","uuid":102123100000,"float_uuid":5.0455515357e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":230,"physical_name":"AGIPD_SIV1_AGIPDV12_M540","karabo_da":"AGIPD13","virtual_device_name":"Q4M2","uuid":102133100000,"float_uuid":5.04604560133e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":231,"physical_name":"AGIPD_SIV1_AGIPDV12_M515","karabo_da":"AGIPD14","virtual_device_name":"Q4M3","uuid":102143100000,"float_uuid":5.04653966697e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":232,"physical_name":"AGIPD_SIV1_AGIPDV12_M544","karabo_da":"AGIPD15","virtual_device_name":"Q4M4","uuid":102153100000,"float_uuid":5.0470337326e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}}]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '10575'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 10 Apr 2026 10:14:15 GMT
+      Etag:
+      - W/"ba18dd44f59a27e5b90cd68a88820653"
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=16070400; includeSubDomains
+      Vary:
+      - Origin
+      Via:
+      - HTTP/1.1 xfel_oauth_proxy
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R)
+      X-Request-Id:
+      - 960241ca-0ab3-42e5-a9d7-cc9bcad066c7
+      X-Runtime:
+      - '0.474364'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json; version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - EXtra/2025.1.194+7868e3e
+      content-type:
+      - application/json
+    method: GET
+    uri: http://exflcalproxy.desy.de:8080/api/physical_detector_units/get_all_by_detector?detector_id=2&pdu_snapshot_at=2026-04-10T11%3A27%3A00%2B00%3A00
+  response:
+    body:
+      string: '[{"id":188,"physical_name":"AGIPD_SIV1_AGIPDV11_M517","karabo_da":"AGIPD00","virtual_device_name":"Q1M1","uuid":101003000000,"float_uuid":4.9902112427e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":218,"physical_name":"AGIPD_SIV1_AGIPDV12_M421","karabo_da":"AGIPD01","virtual_device_name":"Q1M2","uuid":102013100004,"float_uuid":5.04011681377e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":219,"physical_name":"AGIPD_SIV1_AGIPDV12_M445","karabo_da":"AGIPD02","virtual_device_name":"Q1M3","uuid":102023100004,"float_uuid":5.0406108794e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":287,"physical_name":"AGIPD_SIV1_AGIPDV12_M447","karabo_da":"AGIPD03","virtual_device_name":"Q1M4","uuid":102033100010,"float_uuid":5.04110494536e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":"This
+        is a new module installed on 19.06.2025 on position Q1M4","detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":223,"physical_name":"AGIPD_SIV1_AGIPDV12_M410","karabo_da":"AGIPD04","virtual_device_name":"Q2M1","uuid":102063100000,"float_uuid":5.0425871418e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":224,"physical_name":"AGIPD_SIV1_AGIPDV12_M528","karabo_da":"AGIPD05","virtual_device_name":"Q2M2","uuid":102073100000,"float_uuid":5.04308120745e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":248,"physical_name":"AGIPD_SIV1_AGIPDV12_M425","karabo_da":"AGIPD06","virtual_device_name":"Q2M3","uuid":102053100001,"float_uuid":5.0420930762e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":288,"physical_name":"AGIPD_SIV1_AGIPDV12_M411","karabo_da":"AGIPD07","virtual_device_name":"Q2M4","uuid":102033100020,"float_uuid":5.04110494586e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":"This
+        is a new module installed on 19.06.2025 on position Q2M4","detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":225,"physical_name":"AGIPD_SIV1_AGIPDV12_M412","karabo_da":"AGIPD08","virtual_device_name":"Q3M1","uuid":102083100000,"float_uuid":5.0435752731e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":226,"physical_name":"AGIPD_SIV1_AGIPDV12_M542","karabo_da":"AGIPD09","virtual_device_name":"Q3M2","uuid":102093100000,"float_uuid":5.04406933874e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":227,"physical_name":"AGIPD_SIV1_AGIPDV12_M527","karabo_da":"AGIPD10","virtual_device_name":"Q3M3","uuid":102103100000,"float_uuid":5.0445634044e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":228,"physical_name":"AGIPD_SIV1_AGIPDV12_M502","karabo_da":"AGIPD11","virtual_device_name":"Q3M4","uuid":102113100000,"float_uuid":5.04505747004e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":229,"physical_name":"AGIPD_SIV1_AGIPDV12_M426","karabo_da":"AGIPD12","virtual_device_name":"Q4M1","uuid":102123100000,"float_uuid":5.0455515357e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":230,"physical_name":"AGIPD_SIV1_AGIPDV12_M540","karabo_da":"AGIPD13","virtual_device_name":"Q4M2","uuid":102133100000,"float_uuid":5.04604560133e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":231,"physical_name":"AGIPD_SIV1_AGIPDV12_M515","karabo_da":"AGIPD14","virtual_device_name":"Q4M3","uuid":102143100000,"float_uuid":5.04653966697e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":232,"physical_name":"AGIPD_SIV1_AGIPDV12_M544","karabo_da":"AGIPD15","virtual_device_name":"Q4M4","uuid":102153100000,"float_uuid":5.0470337326e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}}]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '10575'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 10 Apr 2026 10:14:15 GMT
+      Etag:
+      - W/"ba18dd44f59a27e5b90cd68a88820653"
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=16070400; includeSubDomains
+      Vary:
+      - Origin
+      Via:
+      - HTTP/1.1 xfel_oauth_proxy
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R)
+      X-Request-Id:
+      - 05b64845-ea17-4224-ad07-62f1cb906ba0
+      X-Runtime:
+      - '0.541108'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json; version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - EXtra/2025.1.194+7868e3e
+      content-type:
+      - application/json
+    method: GET
+    uri: http://exflcalproxy.desy.de:8080/api/physical_detector_units/get_all_by_detector?detector_id=2&pdu_snapshot_at=2026-04-10T11%3A27%3A00%2B00%3A00
+  response:
+    body:
+      string: '[{"id":188,"physical_name":"AGIPD_SIV1_AGIPDV11_M517","karabo_da":"AGIPD00","virtual_device_name":"Q1M1","uuid":101003000000,"float_uuid":4.9902112427e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":218,"physical_name":"AGIPD_SIV1_AGIPDV12_M421","karabo_da":"AGIPD01","virtual_device_name":"Q1M2","uuid":102013100004,"float_uuid":5.04011681377e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":219,"physical_name":"AGIPD_SIV1_AGIPDV12_M445","karabo_da":"AGIPD02","virtual_device_name":"Q1M3","uuid":102023100004,"float_uuid":5.0406108794e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":287,"physical_name":"AGIPD_SIV1_AGIPDV12_M447","karabo_da":"AGIPD03","virtual_device_name":"Q1M4","uuid":102033100010,"float_uuid":5.04110494536e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":"This
+        is a new module installed on 19.06.2025 on position Q1M4","detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":223,"physical_name":"AGIPD_SIV1_AGIPDV12_M410","karabo_da":"AGIPD04","virtual_device_name":"Q2M1","uuid":102063100000,"float_uuid":5.0425871418e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":224,"physical_name":"AGIPD_SIV1_AGIPDV12_M528","karabo_da":"AGIPD05","virtual_device_name":"Q2M2","uuid":102073100000,"float_uuid":5.04308120745e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":248,"physical_name":"AGIPD_SIV1_AGIPDV12_M425","karabo_da":"AGIPD06","virtual_device_name":"Q2M3","uuid":102053100001,"float_uuid":5.0420930762e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":288,"physical_name":"AGIPD_SIV1_AGIPDV12_M411","karabo_da":"AGIPD07","virtual_device_name":"Q2M4","uuid":102033100020,"float_uuid":5.04110494586e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":"This
+        is a new module installed on 19.06.2025 on position Q2M4","detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":225,"physical_name":"AGIPD_SIV1_AGIPDV12_M412","karabo_da":"AGIPD08","virtual_device_name":"Q3M1","uuid":102083100000,"float_uuid":5.0435752731e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":226,"physical_name":"AGIPD_SIV1_AGIPDV12_M542","karabo_da":"AGIPD09","virtual_device_name":"Q3M2","uuid":102093100000,"float_uuid":5.04406933874e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":227,"physical_name":"AGIPD_SIV1_AGIPDV12_M527","karabo_da":"AGIPD10","virtual_device_name":"Q3M3","uuid":102103100000,"float_uuid":5.0445634044e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":228,"physical_name":"AGIPD_SIV1_AGIPDV12_M502","karabo_da":"AGIPD11","virtual_device_name":"Q3M4","uuid":102113100000,"float_uuid":5.04505747004e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":229,"physical_name":"AGIPD_SIV1_AGIPDV12_M426","karabo_da":"AGIPD12","virtual_device_name":"Q4M1","uuid":102123100000,"float_uuid":5.0455515357e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":230,"physical_name":"AGIPD_SIV1_AGIPDV12_M540","karabo_da":"AGIPD13","virtual_device_name":"Q4M2","uuid":102133100000,"float_uuid":5.04604560133e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":231,"physical_name":"AGIPD_SIV1_AGIPDV12_M515","karabo_da":"AGIPD14","virtual_device_name":"Q4M3","uuid":102143100000,"float_uuid":5.04653966697e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":232,"physical_name":"AGIPD_SIV1_AGIPDV12_M544","karabo_da":"AGIPD15","virtual_device_name":"Q4M4","uuid":102153100000,"float_uuid":5.0470337326e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}}]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '10575'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 10 Apr 2026 10:14:16 GMT
+      Etag:
+      - W/"ba18dd44f59a27e5b90cd68a88820653"
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=16070400; includeSubDomains
+      Vary:
+      - Origin
+      Via:
+      - HTTP/1.1 xfel_oauth_proxy
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R)
+      X-Request-Id:
+      - 1bcc4f13-b971-4f96-a388-85b3f2fa0f86
+      X-Runtime:
+      - '0.486908'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json; version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - EXtra/2025.1.194+7868e3e
+      content-type:
+      - application/json
+    method: GET
+    uri: http://exflcalproxy.desy.de:8080/api/detectors?identifier=HED_DET_AGIPD500K2G
+  response:
+    body:
+      string: '[{"id":26,"name":"HED_DET_AGIPD500K2G","identifier":"HED_DET_AGIPD500K2G","karabo_name":"HED_DET_AGIPD500K2G","karabo_id_control":"HED_EXP_AGIPD500K2G","source_name_pattern":"HED_DET_AGIPD500K2G/DET/{modno}CH0:xtdf","number_of_modules":8,"first_module_index":0,"flg_available":true,"description":null,"detectors_instruments":[{"instrument_id":5,"detector_id":26},{"instrument_id":7,"detector_id":26}]}]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '402'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 10 Apr 2026 10:14:17 GMT
+      Etag:
+      - W/"9084db46cf6521fcce9ea4969d567b1a"
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=16070400; includeSubDomains
+      Vary:
+      - Origin
+      Via:
+      - HTTP/1.1 xfel_oauth_proxy
+      X-Content-Type-Options:
+      - nosniff
+      X-Count-Per-Page:
+      - '100'
+      X-Current-Page:
+      - '1'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R)
+      X-Request-Id:
+      - 7808df70-82b5-413c-8f63-1ad356cdd4ad
+      X-Runtime:
+      - '0.026851'
+      X-Total-Count:
+      - '1'
+      X-Total-Pages:
+      - '1'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json; version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - EXtra/2025.1.194+7868e3e
+      content-type:
+      - application/json
+    method: GET
+    uri: http://exflcalproxy.desy.de:8080/api/physical_detector_units/get_all_by_detector?detector_id=26&pdu_snapshot_at=2026-04-10T11%3A27%3A00%2B00%3A00
+  response:
+    body:
+      string: '[{"id":264,"physical_name":"AGIPD_SIV1_AGIPDV12_T119IN","karabo_da":"AGIPD00","virtual_device_name":"Q1M1","uuid":2203003400001,"float_uuid":1.088428297612e-311,"detector_type_id":2,"detector_id":26,"module_number":null,"flg_available":true,"description":null,"detector":{"id":26,"name":"HED_DET_AGIPD500K2G","identifier":"HED_DET_AGIPD500K2G","karabo_name":"HED_DET_AGIPD500K2G","karabo_id_control":"HED_EXP_AGIPD500K2G","source_name_pattern":"HED_DET_AGIPD500K2G/DET/{modno}CH0:xtdf","number_of_modules":8,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":265,"physical_name":"AGIPD_SIV1_AGIPDV12_T119OUT","karabo_da":"AGIPD01","virtual_device_name":"Q1M2","uuid":2203003400002,"float_uuid":1.0884282976125e-311,"detector_type_id":2,"detector_id":26,"module_number":null,"flg_available":true,"description":"Installed
+        on 05.02.2025","detector":{"id":26,"name":"HED_DET_AGIPD500K2G","identifier":"HED_DET_AGIPD500K2G","karabo_name":"HED_DET_AGIPD500K2G","karabo_id_control":"HED_EXP_AGIPD500K2G","source_name_pattern":"HED_DET_AGIPD500K2G/DET/{modno}CH0:xtdf","number_of_modules":8,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":176,"physical_name":"AGIPD_SIV1_AGIPDV11_T001IN","karabo_da":"AGIPD02","virtual_device_name":"Q1M3","uuid":2203003400000,"float_uuid":1.0884282976115e-311,"detector_type_id":2,"detector_id":26,"module_number":null,"flg_available":true,"description":null,"detector":{"id":26,"name":"HED_DET_AGIPD500K2G","identifier":"HED_DET_AGIPD500K2G","karabo_name":"HED_DET_AGIPD500K2G","karabo_id_control":"HED_EXP_AGIPD500K2G","source_name_pattern":"HED_DET_AGIPD500K2G/DET/{modno}CH0:xtdf","number_of_modules":8,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":177,"physical_name":"AGIPD_SIV1_AGIPDV11_T001OUT","karabo_da":"AGIPD03","virtual_device_name":"Q1M4","uuid":2203003500000,"float_uuid":1.088428347018e-311,"detector_type_id":2,"detector_id":26,"module_number":null,"flg_available":true,"description":null,"detector":{"id":26,"name":"HED_DET_AGIPD500K2G","identifier":"HED_DET_AGIPD500K2G","karabo_name":"HED_DET_AGIPD500K2G","karabo_id_control":"HED_EXP_AGIPD500K2G","source_name_pattern":"HED_DET_AGIPD500K2G/DET/{modno}CH0:xtdf","number_of_modules":8,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":157,"physical_name":"AGIPD_SIV1_AGIPDV12_T000IN","karabo_da":"AGIPD04","virtual_device_name":"Q2M1","uuid":2203002800000,"float_uuid":1.088428001172e-311,"detector_type_id":2,"detector_id":26,"module_number":null,"flg_available":true,"description":null,"detector":{"id":26,"name":"HED_DET_AGIPD500K2G","identifier":"HED_DET_AGIPD500K2G","karabo_name":"HED_DET_AGIPD500K2G","karabo_id_control":"HED_EXP_AGIPD500K2G","source_name_pattern":"HED_DET_AGIPD500K2G/DET/{modno}CH0:xtdf","number_of_modules":8,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":158,"physical_name":"AGIPD_SIV1_AGIPDV12_T000OUT","karabo_da":"AGIPD05","virtual_device_name":"Q2M2","uuid":2203002900000,"float_uuid":1.0884280505786e-311,"detector_type_id":2,"detector_id":26,"module_number":null,"flg_available":true,"description":null,"detector":{"id":26,"name":"HED_DET_AGIPD500K2G","identifier":"HED_DET_AGIPD500K2G","karabo_name":"HED_DET_AGIPD500K2G","karabo_id_control":"HED_EXP_AGIPD500K2G","source_name_pattern":"HED_DET_AGIPD500K2G/DET/{modno}CH0:xtdf","number_of_modules":8,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":159,"physical_name":"AGIPD_SIV1_AGIPDV12_T006IN","karabo_da":"AGIPD06","virtual_device_name":"Q2M3","uuid":2203003000000,"float_uuid":1.088428099985e-311,"detector_type_id":2,"detector_id":26,"module_number":null,"flg_available":true,"description":null,"detector":{"id":26,"name":"HED_DET_AGIPD500K2G","identifier":"HED_DET_AGIPD500K2G","karabo_name":"HED_DET_AGIPD500K2G","karabo_id_control":"HED_EXP_AGIPD500K2G","source_name_pattern":"HED_DET_AGIPD500K2G/DET/{modno}CH0:xtdf","number_of_modules":8,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":160,"physical_name":"AGIPD_SIV1_AGIPDV12_T006OUT","karabo_da":"AGIPD07","virtual_device_name":"Q2M4","uuid":2203003100000,"float_uuid":1.088428149392e-311,"detector_type_id":2,"detector_id":26,"module_number":null,"flg_available":true,"description":null,"detector":{"id":26,"name":"HED_DET_AGIPD500K2G","identifier":"HED_DET_AGIPD500K2G","karabo_name":"HED_DET_AGIPD500K2G","karabo_id_control":"HED_EXP_AGIPD500K2G","source_name_pattern":"HED_DET_AGIPD500K2G/DET/{modno}CH0:xtdf","number_of_modules":8,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}}]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '5389'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 10 Apr 2026 10:14:17 GMT
+      Etag:
+      - W/"5f7296dcc28fad37142811d8ed0911b2"
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=16070400; includeSubDomains
+      Vary:
+      - Origin
+      Via:
+      - HTTP/1.1 xfel_oauth_proxy
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R)
+      X-Request-Id:
+      - e610a9a5-d628-443a-8bec-0776a0fb00cd
+      X-Runtime:
+      - '0.475452'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_calibration/test_CalibrationData_from_data.yaml
+++ b/tests/cassettes/test_calibration/test_CalibrationData_from_data.yaml
@@ -1,0 +1,1408 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json; version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - EXtra/2025.1.194+7868e3e
+      content-type:
+      - application/json
+    method: GET
+    uri: http://exflcalproxy.desy.de:8080/api/me
+  response:
+    body:
+      string: '{"id":-9,"email":"admin@example.com","provider":"local","contact_email":"admin@example.com","name":"Admin
+        User","first_name":"Admin","last_name":"User","nickname":null,"uid":null,"ldap_synced_at":null,"flg_service_account":true,"flg_ldap_account_valid":false,"roles":["admin"]}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '277'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 10 Apr 2026 10:09:17 GMT
+      Etag:
+      - W/"9ec4cec974b56aebafbb6dc312056934"
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=16070400; includeSubDomains
+      Vary:
+      - Origin
+      Via:
+      - HTTP/1.1 xfel_oauth_proxy
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R)
+      X-Request-Id:
+      - 573df1ed-1f49-417c-84a0-84570aacc394
+      X-Runtime:
+      - '0.029650'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json; version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - EXtra/2025.1.194+7868e3e
+      content-type:
+      - application/json
+    method: GET
+    uri: http://exflcalproxy.desy.de:8080/api/detectors?identifier=SPB_DET_AGIPD1M-1
+  response:
+    body:
+      string: '[{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null,"detectors_instruments":[{"instrument_id":3,"detector_id":2},{"instrument_id":7,"detector_id":2}]}]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '389'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 10 Apr 2026 10:09:17 GMT
+      Etag:
+      - W/"73d84e307238475d3943984c03827c80"
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=16070400; includeSubDomains
+      Vary:
+      - Origin
+      Via:
+      - HTTP/1.1 xfel_oauth_proxy
+      X-Content-Type-Options:
+      - nosniff
+      X-Count-Per-Page:
+      - '100'
+      X-Current-Page:
+      - '1'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R)
+      X-Request-Id:
+      - b2042a25-7004-407e-92cc-03f43aa2f80f
+      X-Runtime:
+      - '0.030596'
+      X-Total-Count:
+      - '1'
+      X-Total-Pages:
+      - '1'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json; version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - EXtra/2025.1.194+7868e3e
+      content-type:
+      - application/json
+    method: GET
+    uri: http://exflcalproxy.desy.de:8080/api/physical_detector_units/get_all_by_detector?detector_id=2&pdu_snapshot_at=2026-04-10T11%3A27%3A00%2B00%3A00
+  response:
+    body:
+      string: '[{"id":188,"physical_name":"AGIPD_SIV1_AGIPDV11_M517","karabo_da":"AGIPD00","virtual_device_name":"Q1M1","uuid":101003000000,"float_uuid":4.9902112427e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":218,"physical_name":"AGIPD_SIV1_AGIPDV12_M421","karabo_da":"AGIPD01","virtual_device_name":"Q1M2","uuid":102013100004,"float_uuid":5.04011681377e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":219,"physical_name":"AGIPD_SIV1_AGIPDV12_M445","karabo_da":"AGIPD02","virtual_device_name":"Q1M3","uuid":102023100004,"float_uuid":5.0406108794e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":287,"physical_name":"AGIPD_SIV1_AGIPDV12_M447","karabo_da":"AGIPD03","virtual_device_name":"Q1M4","uuid":102033100010,"float_uuid":5.04110494536e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":"This
+        is a new module installed on 19.06.2025 on position Q1M4","detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":223,"physical_name":"AGIPD_SIV1_AGIPDV12_M410","karabo_da":"AGIPD04","virtual_device_name":"Q2M1","uuid":102063100000,"float_uuid":5.0425871418e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":224,"physical_name":"AGIPD_SIV1_AGIPDV12_M528","karabo_da":"AGIPD05","virtual_device_name":"Q2M2","uuid":102073100000,"float_uuid":5.04308120745e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":248,"physical_name":"AGIPD_SIV1_AGIPDV12_M425","karabo_da":"AGIPD06","virtual_device_name":"Q2M3","uuid":102053100001,"float_uuid":5.0420930762e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":288,"physical_name":"AGIPD_SIV1_AGIPDV12_M411","karabo_da":"AGIPD07","virtual_device_name":"Q2M4","uuid":102033100020,"float_uuid":5.04110494586e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":"This
+        is a new module installed on 19.06.2025 on position Q2M4","detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":225,"physical_name":"AGIPD_SIV1_AGIPDV12_M412","karabo_da":"AGIPD08","virtual_device_name":"Q3M1","uuid":102083100000,"float_uuid":5.0435752731e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":226,"physical_name":"AGIPD_SIV1_AGIPDV12_M542","karabo_da":"AGIPD09","virtual_device_name":"Q3M2","uuid":102093100000,"float_uuid":5.04406933874e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":227,"physical_name":"AGIPD_SIV1_AGIPDV12_M527","karabo_da":"AGIPD10","virtual_device_name":"Q3M3","uuid":102103100000,"float_uuid":5.0445634044e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":228,"physical_name":"AGIPD_SIV1_AGIPDV12_M502","karabo_da":"AGIPD11","virtual_device_name":"Q3M4","uuid":102113100000,"float_uuid":5.04505747004e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":229,"physical_name":"AGIPD_SIV1_AGIPDV12_M426","karabo_da":"AGIPD12","virtual_device_name":"Q4M1","uuid":102123100000,"float_uuid":5.0455515357e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":230,"physical_name":"AGIPD_SIV1_AGIPDV12_M540","karabo_da":"AGIPD13","virtual_device_name":"Q4M2","uuid":102133100000,"float_uuid":5.04604560133e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":231,"physical_name":"AGIPD_SIV1_AGIPDV12_M515","karabo_da":"AGIPD14","virtual_device_name":"Q4M3","uuid":102143100000,"float_uuid":5.04653966697e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":232,"physical_name":"AGIPD_SIV1_AGIPDV12_M544","karabo_da":"AGIPD15","virtual_device_name":"Q4M4","uuid":102153100000,"float_uuid":5.0470337326e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}}]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '10575'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 10 Apr 2026 10:09:17 GMT
+      Etag:
+      - W/"ba18dd44f59a27e5b90cd68a88820653"
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=16070400; includeSubDomains
+      Vary:
+      - Origin
+      Via:
+      - HTTP/1.1 xfel_oauth_proxy
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R)
+      X-Request-Id:
+      - 5815d264-bb11-4654-8a33-bbac7d1ba035
+      X-Runtime:
+      - '0.479948'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json; version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - EXtra/2025.1.194+7868e3e
+      content-type:
+      - application/json
+    method: GET
+    uri: http://exflcalproxy.desy.de:8080/api/physical_detector_units/get_all_by_detector?detector_id=2&pdu_snapshot_at=2026-04-10T11%3A27%3A00%2B00%3A00
+  response:
+    body:
+      string: '[{"id":188,"physical_name":"AGIPD_SIV1_AGIPDV11_M517","karabo_da":"AGIPD00","virtual_device_name":"Q1M1","uuid":101003000000,"float_uuid":4.9902112427e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":218,"physical_name":"AGIPD_SIV1_AGIPDV12_M421","karabo_da":"AGIPD01","virtual_device_name":"Q1M2","uuid":102013100004,"float_uuid":5.04011681377e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":219,"physical_name":"AGIPD_SIV1_AGIPDV12_M445","karabo_da":"AGIPD02","virtual_device_name":"Q1M3","uuid":102023100004,"float_uuid":5.0406108794e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":287,"physical_name":"AGIPD_SIV1_AGIPDV12_M447","karabo_da":"AGIPD03","virtual_device_name":"Q1M4","uuid":102033100010,"float_uuid":5.04110494536e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":"This
+        is a new module installed on 19.06.2025 on position Q1M4","detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":223,"physical_name":"AGIPD_SIV1_AGIPDV12_M410","karabo_da":"AGIPD04","virtual_device_name":"Q2M1","uuid":102063100000,"float_uuid":5.0425871418e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":224,"physical_name":"AGIPD_SIV1_AGIPDV12_M528","karabo_da":"AGIPD05","virtual_device_name":"Q2M2","uuid":102073100000,"float_uuid":5.04308120745e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":248,"physical_name":"AGIPD_SIV1_AGIPDV12_M425","karabo_da":"AGIPD06","virtual_device_name":"Q2M3","uuid":102053100001,"float_uuid":5.0420930762e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":288,"physical_name":"AGIPD_SIV1_AGIPDV12_M411","karabo_da":"AGIPD07","virtual_device_name":"Q2M4","uuid":102033100020,"float_uuid":5.04110494586e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":"This
+        is a new module installed on 19.06.2025 on position Q2M4","detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":225,"physical_name":"AGIPD_SIV1_AGIPDV12_M412","karabo_da":"AGIPD08","virtual_device_name":"Q3M1","uuid":102083100000,"float_uuid":5.0435752731e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":226,"physical_name":"AGIPD_SIV1_AGIPDV12_M542","karabo_da":"AGIPD09","virtual_device_name":"Q3M2","uuid":102093100000,"float_uuid":5.04406933874e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":227,"physical_name":"AGIPD_SIV1_AGIPDV12_M527","karabo_da":"AGIPD10","virtual_device_name":"Q3M3","uuid":102103100000,"float_uuid":5.0445634044e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":228,"physical_name":"AGIPD_SIV1_AGIPDV12_M502","karabo_da":"AGIPD11","virtual_device_name":"Q3M4","uuid":102113100000,"float_uuid":5.04505747004e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":229,"physical_name":"AGIPD_SIV1_AGIPDV12_M426","karabo_da":"AGIPD12","virtual_device_name":"Q4M1","uuid":102123100000,"float_uuid":5.0455515357e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":230,"physical_name":"AGIPD_SIV1_AGIPDV12_M540","karabo_da":"AGIPD13","virtual_device_name":"Q4M2","uuid":102133100000,"float_uuid":5.04604560133e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":231,"physical_name":"AGIPD_SIV1_AGIPDV12_M515","karabo_da":"AGIPD14","virtual_device_name":"Q4M3","uuid":102143100000,"float_uuid":5.04653966697e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":232,"physical_name":"AGIPD_SIV1_AGIPDV12_M544","karabo_da":"AGIPD15","virtual_device_name":"Q4M4","uuid":102153100000,"float_uuid":5.0470337326e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}}]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '10575'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 10 Apr 2026 10:09:17 GMT
+      Etag:
+      - W/"ba18dd44f59a27e5b90cd68a88820653"
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=16070400; includeSubDomains
+      Vary:
+      - Origin
+      Via:
+      - HTTP/1.1 xfel_oauth_proxy
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R)
+      X-Request-Id:
+      - dc1e0dc3-ec71-4908-bf6e-76410769149f
+      X-Runtime:
+      - '0.561891'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json; version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - EXtra/2025.1.194+7868e3e
+      content-type:
+      - application/json
+    method: GET
+    uri: http://exflcalproxy.desy.de:8080/api/physical_detector_units/get_all_by_detector?detector_id=2&pdu_snapshot_at=2026-04-10T11%3A27%3A00%2B00%3A00
+  response:
+    body:
+      string: '[{"id":188,"physical_name":"AGIPD_SIV1_AGIPDV11_M517","karabo_da":"AGIPD00","virtual_device_name":"Q1M1","uuid":101003000000,"float_uuid":4.9902112427e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":218,"physical_name":"AGIPD_SIV1_AGIPDV12_M421","karabo_da":"AGIPD01","virtual_device_name":"Q1M2","uuid":102013100004,"float_uuid":5.04011681377e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":219,"physical_name":"AGIPD_SIV1_AGIPDV12_M445","karabo_da":"AGIPD02","virtual_device_name":"Q1M3","uuid":102023100004,"float_uuid":5.0406108794e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":287,"physical_name":"AGIPD_SIV1_AGIPDV12_M447","karabo_da":"AGIPD03","virtual_device_name":"Q1M4","uuid":102033100010,"float_uuid":5.04110494536e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":"This
+        is a new module installed on 19.06.2025 on position Q1M4","detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":223,"physical_name":"AGIPD_SIV1_AGIPDV12_M410","karabo_da":"AGIPD04","virtual_device_name":"Q2M1","uuid":102063100000,"float_uuid":5.0425871418e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":224,"physical_name":"AGIPD_SIV1_AGIPDV12_M528","karabo_da":"AGIPD05","virtual_device_name":"Q2M2","uuid":102073100000,"float_uuid":5.04308120745e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":248,"physical_name":"AGIPD_SIV1_AGIPDV12_M425","karabo_da":"AGIPD06","virtual_device_name":"Q2M3","uuid":102053100001,"float_uuid":5.0420930762e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":288,"physical_name":"AGIPD_SIV1_AGIPDV12_M411","karabo_da":"AGIPD07","virtual_device_name":"Q2M4","uuid":102033100020,"float_uuid":5.04110494586e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":"This
+        is a new module installed on 19.06.2025 on position Q2M4","detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":225,"physical_name":"AGIPD_SIV1_AGIPDV12_M412","karabo_da":"AGIPD08","virtual_device_name":"Q3M1","uuid":102083100000,"float_uuid":5.0435752731e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":226,"physical_name":"AGIPD_SIV1_AGIPDV12_M542","karabo_da":"AGIPD09","virtual_device_name":"Q3M2","uuid":102093100000,"float_uuid":5.04406933874e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":227,"physical_name":"AGIPD_SIV1_AGIPDV12_M527","karabo_da":"AGIPD10","virtual_device_name":"Q3M3","uuid":102103100000,"float_uuid":5.0445634044e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":228,"physical_name":"AGIPD_SIV1_AGIPDV12_M502","karabo_da":"AGIPD11","virtual_device_name":"Q3M4","uuid":102113100000,"float_uuid":5.04505747004e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":229,"physical_name":"AGIPD_SIV1_AGIPDV12_M426","karabo_da":"AGIPD12","virtual_device_name":"Q4M1","uuid":102123100000,"float_uuid":5.0455515357e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":230,"physical_name":"AGIPD_SIV1_AGIPDV12_M540","karabo_da":"AGIPD13","virtual_device_name":"Q4M2","uuid":102133100000,"float_uuid":5.04604560133e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":231,"physical_name":"AGIPD_SIV1_AGIPDV12_M515","karabo_da":"AGIPD14","virtual_device_name":"Q4M3","uuid":102143100000,"float_uuid":5.04653966697e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}},{"id":232,"physical_name":"AGIPD_SIV1_AGIPDV12_M544","karabo_da":"AGIPD15","virtual_device_name":"Q4M4","uuid":102153100000,"float_uuid":5.0470337326e-313,"detector_type_id":2,"detector_id":2,"module_number":null,"flg_available":true,"description":null,"detector":{"id":2,"name":"SPB_DET_AGIPD1M-1","identifier":"SPB_DET_AGIPD1M-1","karabo_name":"SPB_DET_AGIPD1M-1","karabo_id_control":"SPB_IRU_AGIPD1M1","source_name_pattern":"SPB_DET_AGIPD1M-1/DET/{modno}CH0:xtdf","number_of_modules":16,"first_module_index":0,"flg_available":true,"description":null},"detector_type":{"id":2,"name":"AGIPD-Type","flg_available":true,"description":"AGIPDConditions"}}]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '10575'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 10 Apr 2026 10:09:18 GMT
+      Etag:
+      - W/"ba18dd44f59a27e5b90cd68a88820653"
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=16070400; includeSubDomains
+      Vary:
+      - Origin
+      Via:
+      - HTTP/1.1 xfel_oauth_proxy
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R)
+      X-Request-Id:
+      - 40a0168c-b49e-4171-9476-c3c22f217282
+      X-Runtime:
+      - '0.584756'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json; version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - EXtra/2025.1.194+7868e3e
+      content-type:
+      - application/json
+    method: GET
+    uri: http://exflcalproxy.desy.de:8080/api/calibrations?name=Offset
+  response:
+    body:
+      string: '[{"id":1,"name":"Offset","unit_id":1,"max_value":null,"min_value":null,"allowed_deviation":null,"description":""}]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '114'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 10 Apr 2026 10:09:19 GMT
+      Etag:
+      - W/"41e8088cc44ad976e577e40482d74dfb"
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=16070400; includeSubDomains
+      Vary:
+      - Origin
+      Via:
+      - HTTP/1.1 xfel_oauth_proxy
+      X-Content-Type-Options:
+      - nosniff
+      X-Count-Per-Page:
+      - '100'
+      X-Current-Page:
+      - '1'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R)
+      X-Request-Id:
+      - 2f6fe932-3510-4b9d-9147-d185841990d6
+      X-Runtime:
+      - '0.022959'
+      X-Total-Count:
+      - '1'
+      X-Total-Pages:
+      - '1'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json; version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - EXtra/2025.1.194+7868e3e
+      content-type:
+      - application/json
+    method: GET
+    uri: http://exflcalproxy.desy.de:8080/api/calibrations?name=Noise
+  response:
+    body:
+      string: '[{"id":2,"name":"Noise","unit_id":1,"max_value":null,"min_value":null,"allowed_deviation":null,"description":"In
+        terms of standard deviation"}]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '143'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 10 Apr 2026 10:09:19 GMT
+      Etag:
+      - W/"f1826d5b0b4d30aa8e2a90eb504451d1"
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=16070400; includeSubDomains
+      Vary:
+      - Origin
+      Via:
+      - HTTP/1.1 xfel_oauth_proxy
+      X-Content-Type-Options:
+      - nosniff
+      X-Count-Per-Page:
+      - '100'
+      X-Current-Page:
+      - '1'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R)
+      X-Request-Id:
+      - 910e1729-fa69-4029-974e-b630e164bbfe
+      X-Runtime:
+      - '0.030932'
+      X-Total-Count:
+      - '1'
+      X-Total-Pages:
+      - '1'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json; version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - EXtra/2025.1.194+7868e3e
+      content-type:
+      - application/json
+    method: GET
+    uri: http://exflcalproxy.desy.de:8080/api/calibrations?name=ThresholdsDark
+  response:
+    body:
+      string: '[{"id":11,"name":"ThresholdsDark","unit_id":1,"max_value":null,"min_value":null,"allowed_deviation":null,"description":""}]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '123'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 10 Apr 2026 10:09:19 GMT
+      Etag:
+      - W/"f43889846a525288071dc7af3cbabc47"
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=16070400; includeSubDomains
+      Vary:
+      - Origin
+      Via:
+      - HTTP/1.1 xfel_oauth_proxy
+      X-Content-Type-Options:
+      - nosniff
+      X-Count-Per-Page:
+      - '100'
+      X-Current-Page:
+      - '1'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R)
+      X-Request-Id:
+      - 94182e23-8704-46ba-b5c2-279202eb064a
+      X-Runtime:
+      - '0.023253'
+      X-Total-Count:
+      - '1'
+      X-Total-Pages:
+      - '1'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json; version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - EXtra/2025.1.194+7868e3e
+      content-type:
+      - application/json
+    method: GET
+    uri: http://exflcalproxy.desy.de:8080/api/calibrations?name=BadPixelsDark
+  response:
+    body:
+      string: '[{"id":14,"name":"BadPixelsDark","unit_id":1,"max_value":null,"min_value":null,"allowed_deviation":null,"description":""}]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '122'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 10 Apr 2026 10:09:19 GMT
+      Etag:
+      - W/"0e4753c0e3b62586fa4dd1eadedc8ec2"
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=16070400; includeSubDomains
+      Vary:
+      - Origin
+      Via:
+      - HTTP/1.1 xfel_oauth_proxy
+      X-Content-Type-Options:
+      - nosniff
+      X-Count-Per-Page:
+      - '100'
+      X-Current-Page:
+      - '1'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R)
+      X-Request-Id:
+      - c16ca413-bcf2-4399-9250-505850c60186
+      X-Runtime:
+      - '0.027608'
+      X-Total-Count:
+      - '1'
+      X-Total-Pages:
+      - '1'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"parameters_conditions_attributes": [{"parameter_name": "Sensor Bias Voltage",
+      "value": 300.0}, {"parameter_name": "Pixels X", "value": 512.0}, {"parameter_name":
+      "Pixels Y", "value": 128.0}, {"parameter_name": "Memory cells", "value": 0.0},
+      {"parameter_name": "Acquisition rate", "value": 4.5}, {"parameter_name": "Gain
+      setting", "value": 0.0}, {"parameter_name": "Integration time", "value": 15.0}]}'
+    headers:
+      Accept:
+      - application/json; version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '402'
+      User-Agent:
+      - EXtra/2025.1.194+7868e3e
+      content-type:
+      - application/json
+    method: GET
+    uri: http://exflcalproxy.desy.de:8080/api/calibration_constant_versions/get_by_detector_conditions?detector_identifier=SPB_DET_AGIPD1M-1&calibration_id=%5B1%2C+2%2C+11%2C+14%5D&karabo_da=&event_at=2026-04-10T11%3A27%3A00%2B00%3A00&pdu_snapshot_at=2026-04-10T11%3A27%3A00%2B00%3A00&begin_at_strategy=closest
+  response:
+    body:
+      string: '[]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 10 Apr 2026 10:09:19 GMT
+      Etag:
+      - W/"4f53cda18c2baa0c0354bb5f9a3ecbe5"
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=16070400; includeSubDomains
+      Vary:
+      - Origin
+      Via:
+      - HTTP/1.1 xfel_oauth_proxy
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R)
+      X-Request-Id:
+      - 2dbc00ef-8a67-4a9e-b650-eb0f9b2f925d
+      X-Runtime:
+      - '0.531314'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json; version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - EXtra/2025.1.194+7868e3e
+      content-type:
+      - application/json
+    method: GET
+    uri: http://exflcalproxy.desy.de:8080/api/calibrations?name=BadPixelsPC
+  response:
+    body:
+      string: '[{"id":15,"name":"BadPixelsPC","unit_id":1,"max_value":null,"min_value":null,"allowed_deviation":null,"description":""}]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '120'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 10 Apr 2026 10:09:19 GMT
+      Etag:
+      - W/"59c04585d60766363edf6d7d8b2b1de5"
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=16070400; includeSubDomains
+      Vary:
+      - Origin
+      Via:
+      - HTTP/1.1 xfel_oauth_proxy
+      X-Content-Type-Options:
+      - nosniff
+      X-Count-Per-Page:
+      - '100'
+      X-Current-Page:
+      - '1'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R)
+      X-Request-Id:
+      - 8c65b483-4994-4cb2-9dae-10417738b781
+      X-Runtime:
+      - '0.028659'
+      X-Total-Count:
+      - '1'
+      X-Total-Pages:
+      - '1'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json; version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - EXtra/2025.1.194+7868e3e
+      content-type:
+      - application/json
+    method: GET
+    uri: http://exflcalproxy.desy.de:8080/api/calibrations?name=SlopesPC
+  response:
+    body:
+      string: '[{"id":17,"name":"SlopesPC","unit_id":19,"max_value":null,"min_value":null,"allowed_deviation":null,"description":""}]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '118'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 10 Apr 2026 10:09:19 GMT
+      Etag:
+      - W/"2cd54fe20b3b330444a62a1f2c8e42f5"
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=16070400; includeSubDomains
+      Vary:
+      - Origin
+      Via:
+      - HTTP/1.1 xfel_oauth_proxy
+      X-Content-Type-Options:
+      - nosniff
+      X-Count-Per-Page:
+      - '100'
+      X-Current-Page:
+      - '1'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R)
+      X-Request-Id:
+      - 47f1b107-bbf9-42b2-81b0-21fef3e67668
+      X-Runtime:
+      - '0.023490'
+      X-Total-Count:
+      - '1'
+      X-Total-Pages:
+      - '1'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"parameters_conditions_attributes": [{"parameter_name": "Sensor Bias Voltage",
+      "value": 300.0}, {"parameter_name": "Pixels X", "value": 512.0}, {"parameter_name":
+      "Pixels Y", "value": 128.0}, {"parameter_name": "Memory cells", "value": 0.0},
+      {"parameter_name": "Acquisition rate", "value": 4.5}, {"parameter_name": "Gain
+      setting", "value": 0.0}, {"parameter_name": "Integration time", "value": 15.0}]}'
+    headers:
+      Accept:
+      - application/json; version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '402'
+      User-Agent:
+      - EXtra/2025.1.194+7868e3e
+      content-type:
+      - application/json
+    method: GET
+    uri: http://exflcalproxy.desy.de:8080/api/calibration_constant_versions/get_by_detector_conditions?detector_identifier=SPB_DET_AGIPD1M-1&calibration_id=%5B15%2C+17%5D&karabo_da=&event_at=2026-04-10T11%3A27%3A00%2B00%3A00&pdu_snapshot_at=2026-04-10T11%3A27%3A00%2B00%3A00&begin_at_strategy=closest
+  response:
+    body:
+      string: '[]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 10 Apr 2026 10:09:19 GMT
+      Etag:
+      - W/"4f53cda18c2baa0c0354bb5f9a3ecbe5"
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=16070400; includeSubDomains
+      Vary:
+      - Origin
+      Via:
+      - HTTP/1.1 xfel_oauth_proxy
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R)
+      X-Request-Id:
+      - aadbc8d7-cf25-4776-9087-47bed0a78fe5
+      X-Runtime:
+      - '0.651402'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json; version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - EXtra/2025.1.194+7868e3e
+      content-type:
+      - application/json
+    method: GET
+    uri: http://exflcalproxy.desy.de:8080/api/calibrations?name=BadPixelsFF
+  response:
+    body:
+      string: '[{"id":20,"name":"BadPixelsFF","unit_id":19,"max_value":null,"min_value":null,"allowed_deviation":null,"description":""}]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '121'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 10 Apr 2026 10:09:20 GMT
+      Etag:
+      - W/"8d637e112231afb0794d657d8bf9dd6c"
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=16070400; includeSubDomains
+      Vary:
+      - Origin
+      Via:
+      - HTTP/1.1 xfel_oauth_proxy
+      X-Content-Type-Options:
+      - nosniff
+      X-Count-Per-Page:
+      - '100'
+      X-Current-Page:
+      - '1'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R)
+      X-Request-Id:
+      - 63f6b53c-65c0-4061-b595-73464532b871
+      X-Runtime:
+      - '0.023220'
+      X-Total-Count:
+      - '1'
+      X-Total-Pages:
+      - '1'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json; version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - EXtra/2025.1.194+7868e3e
+      content-type:
+      - application/json
+    method: GET
+    uri: http://exflcalproxy.desy.de:8080/api/calibrations?name=SlopesFF
+  response:
+    body:
+      string: '[{"id":19,"name":"SlopesFF","unit_id":19,"max_value":null,"min_value":null,"allowed_deviation":null,"description":""}]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '118'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 10 Apr 2026 10:09:20 GMT
+      Etag:
+      - W/"50ec44b55aad814d2d09049e151bfba8"
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=16070400; includeSubDomains
+      Vary:
+      - Origin
+      Via:
+      - HTTP/1.1 xfel_oauth_proxy
+      X-Content-Type-Options:
+      - nosniff
+      X-Count-Per-Page:
+      - '100'
+      X-Current-Page:
+      - '1'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R)
+      X-Request-Id:
+      - a0ab172e-f487-4796-838c-b269debf5124
+      X-Runtime:
+      - '0.025779'
+      X-Total-Count:
+      - '1'
+      X-Total-Pages:
+      - '1'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"parameters_conditions_attributes": [{"parameter_name": "Sensor Bias Voltage",
+      "value": 300.0}, {"parameter_name": "Pixels X", "value": 512.0}, {"parameter_name":
+      "Pixels Y", "value": 128.0}, {"parameter_name": "Memory cells", "value": 0.0},
+      {"parameter_name": "Acquisition rate", "value": 4.5}, {"parameter_name": "Gain
+      setting", "value": 0.0}, {"parameter_name": "Integration time", "value": 15.0},
+      {"parameter_name": "Source energy", "value": 9.2}]}'
+    headers:
+      Accept:
+      - application/json; version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '453'
+      User-Agent:
+      - EXtra/2025.1.194+7868e3e
+      content-type:
+      - application/json
+    method: GET
+    uri: http://exflcalproxy.desy.de:8080/api/calibration_constant_versions/get_by_detector_conditions?detector_identifier=SPB_DET_AGIPD1M-1&calibration_id=%5B20%2C+19%5D&karabo_da=&event_at=2026-04-10T11%3A27%3A00%2B00%3A00&pdu_snapshot_at=2026-04-10T11%3A27%3A00%2B00%3A00&begin_at_strategy=closest
+  response:
+    body:
+      string: '[]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 10 Apr 2026 10:09:20 GMT
+      Etag:
+      - W/"4f53cda18c2baa0c0354bb5f9a3ecbe5"
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=16070400; includeSubDomains
+      Vary:
+      - Origin
+      Via:
+      - HTTP/1.1 xfel_oauth_proxy
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R)
+      X-Request-Id:
+      - 7470f64b-1b48-4449-9b78-735638a4e071
+      X-Runtime:
+      - '0.516684'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json; version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - EXtra/2025.1.194+7868e3e
+      content-type:
+      - application/json
+    method: GET
+    uri: http://exflcalproxy.desy.de:8080/api/calibrations?name=BadPixelsCS
+  response:
+    body:
+      string: '[{"id":53,"name":"BadPixelsCS","unit_id":1,"max_value":null,"min_value":null,"allowed_deviation":null,"description":null}]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '122'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 10 Apr 2026 10:09:21 GMT
+      Etag:
+      - W/"c11c6520c54719bf5c1edc981d506336"
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=16070400; includeSubDomains
+      Vary:
+      - Origin
+      Via:
+      - HTTP/1.1 xfel_oauth_proxy
+      X-Content-Type-Options:
+      - nosniff
+      X-Count-Per-Page:
+      - '100'
+      X-Current-Page:
+      - '1'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R)
+      X-Request-Id:
+      - 2a80f83f-8b66-409f-8827-fdfcdaf98db7
+      X-Runtime:
+      - '0.022899'
+      X-Total-Count:
+      - '1'
+      X-Total-Pages:
+      - '1'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json; version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - EXtra/2025.1.194+7868e3e
+      content-type:
+      - application/json
+    method: GET
+    uri: http://exflcalproxy.desy.de:8080/api/calibrations?name=SlopesCS
+  response:
+    body:
+      string: '[{"id":52,"name":"SlopesCS","unit_id":19,"max_value":null,"min_value":null,"allowed_deviation":null,"description":"AGIPD
+        shape: (8, memcells, 128, 512)"}]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '154'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 10 Apr 2026 10:09:21 GMT
+      Etag:
+      - W/"5bf5a1a09e63363e880c5fddd834200a"
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=16070400; includeSubDomains
+      Vary:
+      - Origin
+      Via:
+      - HTTP/1.1 xfel_oauth_proxy
+      X-Content-Type-Options:
+      - nosniff
+      X-Count-Per-Page:
+      - '100'
+      X-Current-Page:
+      - '1'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R)
+      X-Request-Id:
+      - 4102bd21-dbc1-4db9-9476-ef442fcf80e7
+      X-Runtime:
+      - '0.026728'
+      X-Total-Count:
+      - '1'
+      X-Total-Pages:
+      - '1'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"parameters_conditions_attributes": [{"parameter_name": "Sensor Bias Voltage",
+      "value": 300.0}, {"parameter_name": "Pixels X", "value": 512.0}, {"parameter_name":
+      "Pixels Y", "value": 128.0}, {"parameter_name": "Memory cells", "value": 0.0},
+      {"parameter_name": "Acquisition rate", "value": 4.5}, {"parameter_name": "Gain
+      setting", "value": 0.0}]}'
+    headers:
+      Accept:
+      - application/json; version=2
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '347'
+      User-Agent:
+      - EXtra/2025.1.194+7868e3e
+      content-type:
+      - application/json
+    method: GET
+    uri: http://exflcalproxy.desy.de:8080/api/calibration_constant_versions/get_by_detector_conditions?detector_identifier=SPB_DET_AGIPD1M-1&calibration_id=%5B53%2C+52%5D&karabo_da=&event_at=2026-04-10T11%3A27%3A00%2B00%3A00&pdu_snapshot_at=2026-04-10T11%3A27%3A00%2B00%3A00&begin_at_strategy=closest
+  response:
+    body:
+      string: '[{"id":207709,"name":"20240531_071339_sIdx=0","file_name":"cal.1717139618.4279437.h5","path_to_file":"xfel/cal/agipd-type/agipd_siv1_agipdv12_m421/","data_set_name":"/AGIPD_SIV1_AGIPDV12_M421/BadPixelsCS/0","flg_deployed":true,"flg_good_quality":true,"begin_validity_at":"2023-12-15T17:21:07.000+01:00","end_validity_at":null,"begin_at":"2023-12-15T17:21:07.000+01:00","start_idx":0,"end_idx":0,"raw_data_location":"Proposal:
+        p900376, Run: 264","report_id":null,"description":"","created_at":"2024-05-31T09:13:39.000+02:00","view_url":"https://in.xfel.eu/calibration/calibration_constant_versions/207709","calibration_constant":{"id":33903,"name":"AGIPD-Type_BadPixelsCS_AGIPD
+        Defuxrj+sznxr52f7KH5KsCkw==\n-2","detector_type_id":2,"calibration_id":53,"condition_id":10974,"flg_auto_approve":true,"flg_available":true,"description":"Per-pixel
+        (per-memory cell) bad pixels from CS runs","created_at":"2023-10-20T13:29:17.000+02:00","updated_at":"2025-11-28T09:55:00.000+01:00"},"physical_detector_unit":{"id":218,"physical_name":"AGIPD_SIV1_AGIPDV12_M421","detector_type_id":2,"flg_available":true,"description":null,"created_at":"2023-12-08T12:48:54.000+01:00","updated_at":"2023-12-08T13:10:28.000+01:00","karabo_da":"AGIPD01","detector_id":2,"virtual_device_name":"Q1M2","uuid":102013100004,"float_uuid":5.04011681377e-313,"module_number":null,"karabo_da_at_ccv_begin_at":"AGIPD01","detector_id_at_ccv_begin_at":2,"virtual_device_name_at_ccv_begin_at":"Q1M2","module_number_at_ccv_begin_at":null}},{"id":201659,"name":"20240425_152557_sIdx=0","file_name":"cal.1714058756.6226678.h5","path_to_file":"xfel/cal/agipd-type/agipd_siv1_agipdv12_m421/","data_set_name":"/AGIPD_SIV1_AGIPDV12_M421/SlopesCS/0","flg_deployed":true,"flg_good_quality":true,"begin_validity_at":"2023-12-15T17:21:07.000+01:00","end_validity_at":null,"begin_at":"2023-12-15T17:21:07.000+01:00","start_idx":0,"end_idx":0,"raw_data_location":"Proposal:
+        p900376, Run: 264","report_id":null,"description":"","created_at":"2024-04-25T17:25:57.000+02:00","view_url":"https://in.xfel.eu/calibration/calibration_constant_versions/201659","calibration_constant":{"id":33902,"name":"AGIPD-Type_SlopesCS_AGIPD
+        Defuxrj+sznxr52f7KH5KsCkw==\n-2","detector_type_id":2,"calibration_id":52,"condition_id":10974,"flg_auto_approve":true,"flg_available":true,"description":"\n                Constants
+        are saved with the following notation:\n                  - Slopes:\n                    -
+        mH: high gain slope\n                    - mM: medium gain slope\n                    -
+        mL: low gain slope\n                  - Intercepts:\n                    -
+        bH: high gain intercept\n                    - bM: medium gain intercept\n                    -
+        bL: low gain intercept\n                  - Ratios:\n                    -
+        H-M: ratio of high gain and medium gain slope\n                    - M-L:
+        ratio of medium gain and low gain slope\n                ","created_at":"2023-10-20T13:29:12.000+02:00","updated_at":"2025-11-28T09:54:59.000+01:00"},"physical_detector_unit":{"id":218,"physical_name":"AGIPD_SIV1_AGIPDV12_M421","detector_type_id":2,"flg_available":true,"description":null,"created_at":"2023-12-08T12:48:54.000+01:00","updated_at":"2023-12-08T13:10:28.000+01:00","karabo_da":"AGIPD01","detector_id":2,"virtual_device_name":"Q1M2","uuid":102013100004,"float_uuid":5.04011681377e-313,"module_number":null,"karabo_da_at_ccv_begin_at":"AGIPD01","detector_id_at_ccv_begin_at":2,"virtual_device_name_at_ccv_begin_at":"Q1M2","module_number_at_ccv_begin_at":null}},{"id":207710,"name":"20240531_071345_sIdx=0","file_name":"cal.1717139624.2530348.h5","path_to_file":"xfel/cal/agipd-type/agipd_siv1_agipdv12_m445/","data_set_name":"/AGIPD_SIV1_AGIPDV12_M445/BadPixelsCS/0","flg_deployed":true,"flg_good_quality":true,"begin_validity_at":"2023-12-15T17:21:07.000+01:00","end_validity_at":null,"begin_at":"2023-12-15T17:21:07.000+01:00","start_idx":0,"end_idx":0,"raw_data_location":"Proposal:
+        p900376, Run: 264","report_id":null,"description":"","created_at":"2024-05-31T09:13:45.000+02:00","view_url":"https://in.xfel.eu/calibration/calibration_constant_versions/207710","calibration_constant":{"id":33903,"name":"AGIPD-Type_BadPixelsCS_AGIPD
+        Defuxrj+sznxr52f7KH5KsCkw==\n-2","detector_type_id":2,"calibration_id":53,"condition_id":10974,"flg_auto_approve":true,"flg_available":true,"description":"Per-pixel
+        (per-memory cell) bad pixels from CS runs","created_at":"2023-10-20T13:29:17.000+02:00","updated_at":"2025-11-28T09:55:00.000+01:00"},"physical_detector_unit":{"id":219,"physical_name":"AGIPD_SIV1_AGIPDV12_M445","detector_type_id":2,"flg_available":true,"description":null,"created_at":"2023-12-08T12:49:23.000+01:00","updated_at":"2023-12-08T13:10:28.000+01:00","karabo_da":"AGIPD02","detector_id":2,"virtual_device_name":"Q1M3","uuid":102023100004,"float_uuid":5.0406108794e-313,"module_number":null,"karabo_da_at_ccv_begin_at":"AGIPD02","detector_id_at_ccv_begin_at":2,"virtual_device_name_at_ccv_begin_at":"Q1M3","module_number_at_ccv_begin_at":null}},{"id":201661,"name":"20240425_152605_sIdx=0","file_name":"cal.1714058764.6862826.h5","path_to_file":"xfel/cal/agipd-type/agipd_siv1_agipdv12_m445/","data_set_name":"/AGIPD_SIV1_AGIPDV12_M445/SlopesCS/0","flg_deployed":true,"flg_good_quality":true,"begin_validity_at":"2023-12-15T17:21:07.000+01:00","end_validity_at":null,"begin_at":"2023-12-15T17:21:07.000+01:00","start_idx":0,"end_idx":0,"raw_data_location":"Proposal:
+        p900376, Run: 264","report_id":null,"description":"","created_at":"2024-04-25T17:26:05.000+02:00","view_url":"https://in.xfel.eu/calibration/calibration_constant_versions/201661","calibration_constant":{"id":33902,"name":"AGIPD-Type_SlopesCS_AGIPD
+        Defuxrj+sznxr52f7KH5KsCkw==\n-2","detector_type_id":2,"calibration_id":52,"condition_id":10974,"flg_auto_approve":true,"flg_available":true,"description":"\n                Constants
+        are saved with the following notation:\n                  - Slopes:\n                    -
+        mH: high gain slope\n                    - mM: medium gain slope\n                    -
+        mL: low gain slope\n                  - Intercepts:\n                    -
+        bH: high gain intercept\n                    - bM: medium gain intercept\n                    -
+        bL: low gain intercept\n                  - Ratios:\n                    -
+        H-M: ratio of high gain and medium gain slope\n                    - M-L:
+        ratio of medium gain and low gain slope\n                ","created_at":"2023-10-20T13:29:12.000+02:00","updated_at":"2025-11-28T09:54:59.000+01:00"},"physical_detector_unit":{"id":219,"physical_name":"AGIPD_SIV1_AGIPDV12_M445","detector_type_id":2,"flg_available":true,"description":null,"created_at":"2023-12-08T12:49:23.000+01:00","updated_at":"2023-12-08T13:10:28.000+01:00","karabo_da":"AGIPD02","detector_id":2,"virtual_device_name":"Q1M3","uuid":102023100004,"float_uuid":5.0406108794e-313,"module_number":null,"karabo_da_at_ccv_begin_at":"AGIPD02","detector_id_at_ccv_begin_at":2,"virtual_device_name_at_ccv_begin_at":"Q1M3","module_number_at_ccv_begin_at":null}},{"id":207714,"name":"20240531_071408_sIdx=0","file_name":"cal.1717139647.581558.h5","path_to_file":"xfel/cal/agipd-type/agipd_siv1_agipdv12_m410/","data_set_name":"/AGIPD_SIV1_AGIPDV12_M410/BadPixelsCS/0","flg_deployed":true,"flg_good_quality":true,"begin_validity_at":"2023-12-15T17:21:07.000+01:00","end_validity_at":null,"begin_at":"2023-12-15T17:21:07.000+01:00","start_idx":0,"end_idx":0,"raw_data_location":"Proposal:
+        p900376, Run: 264","report_id":null,"description":"","created_at":"2024-05-31T09:14:08.000+02:00","view_url":"https://in.xfel.eu/calibration/calibration_constant_versions/207714","calibration_constant":{"id":33903,"name":"AGIPD-Type_BadPixelsCS_AGIPD
+        Defuxrj+sznxr52f7KH5KsCkw==\n-2","detector_type_id":2,"calibration_id":53,"condition_id":10974,"flg_auto_approve":true,"flg_available":true,"description":"Per-pixel
+        (per-memory cell) bad pixels from CS runs","created_at":"2023-10-20T13:29:17.000+02:00","updated_at":"2025-11-28T09:55:00.000+01:00"},"physical_detector_unit":{"id":223,"physical_name":"AGIPD_SIV1_AGIPDV12_M410","detector_type_id":2,"flg_available":true,"description":null,"created_at":"2023-12-08T12:57:14.000+01:00","updated_at":"2024-07-05T12:31:00.000+02:00","karabo_da":"AGIPD04","detector_id":2,"virtual_device_name":"Q2M1","uuid":102063100000,"float_uuid":5.0425871418e-313,"module_number":null,"karabo_da_at_ccv_begin_at":"AGIPD06","detector_id_at_ccv_begin_at":2,"virtual_device_name_at_ccv_begin_at":"Q2M3","module_number_at_ccv_begin_at":null}},{"id":201669,"name":"20240425_152638_sIdx=0","file_name":"cal.1714058797.2871294.h5","path_to_file":"xfel/cal/agipd-type/agipd_siv1_agipdv12_m410/","data_set_name":"/AGIPD_SIV1_AGIPDV12_M410/SlopesCS/0","flg_deployed":true,"flg_good_quality":true,"begin_validity_at":"2023-12-15T17:21:07.000+01:00","end_validity_at":null,"begin_at":"2023-12-15T17:21:07.000+01:00","start_idx":0,"end_idx":0,"raw_data_location":"Proposal:
+        p900376, Run: 264","report_id":null,"description":"","created_at":"2024-04-25T17:26:38.000+02:00","view_url":"https://in.xfel.eu/calibration/calibration_constant_versions/201669","calibration_constant":{"id":33902,"name":"AGIPD-Type_SlopesCS_AGIPD
+        Defuxrj+sznxr52f7KH5KsCkw==\n-2","detector_type_id":2,"calibration_id":52,"condition_id":10974,"flg_auto_approve":true,"flg_available":true,"description":"\n                Constants
+        are saved with the following notation:\n                  - Slopes:\n                    -
+        mH: high gain slope\n                    - mM: medium gain slope\n                    -
+        mL: low gain slope\n                  - Intercepts:\n                    -
+        bH: high gain intercept\n                    - bM: medium gain intercept\n                    -
+        bL: low gain intercept\n                  - Ratios:\n                    -
+        H-M: ratio of high gain and medium gain slope\n                    - M-L:
+        ratio of medium gain and low gain slope\n                ","created_at":"2023-10-20T13:29:12.000+02:00","updated_at":"2025-11-28T09:54:59.000+01:00"},"physical_detector_unit":{"id":223,"physical_name":"AGIPD_SIV1_AGIPDV12_M410","detector_type_id":2,"flg_available":true,"description":null,"created_at":"2023-12-08T12:57:14.000+01:00","updated_at":"2024-07-05T12:31:00.000+02:00","karabo_da":"AGIPD04","detector_id":2,"virtual_device_name":"Q2M1","uuid":102063100000,"float_uuid":5.0425871418e-313,"module_number":null,"karabo_da_at_ccv_begin_at":"AGIPD06","detector_id_at_ccv_begin_at":2,"virtual_device_name_at_ccv_begin_at":"Q2M3","module_number_at_ccv_begin_at":null}},{"id":207715,"name":"20240531_071414_sIdx=0","file_name":"cal.1717139653.4158914.h5","path_to_file":"xfel/cal/agipd-type/agipd_siv1_agipdv12_m528/","data_set_name":"/AGIPD_SIV1_AGIPDV12_M528/BadPixelsCS/0","flg_deployed":true,"flg_good_quality":true,"begin_validity_at":"2023-12-15T17:21:07.000+01:00","end_validity_at":null,"begin_at":"2023-12-15T17:21:07.000+01:00","start_idx":0,"end_idx":0,"raw_data_location":"Proposal:
+        p900376, Run: 264","report_id":null,"description":"","created_at":"2024-05-31T09:14:14.000+02:00","view_url":"https://in.xfel.eu/calibration/calibration_constant_versions/207715","calibration_constant":{"id":33903,"name":"AGIPD-Type_BadPixelsCS_AGIPD
+        Defuxrj+sznxr52f7KH5KsCkw==\n-2","detector_type_id":2,"calibration_id":53,"condition_id":10974,"flg_auto_approve":true,"flg_available":true,"description":"Per-pixel
+        (per-memory cell) bad pixels from CS runs","created_at":"2023-10-20T13:29:17.000+02:00","updated_at":"2025-11-28T09:55:00.000+01:00"},"physical_detector_unit":{"id":224,"physical_name":"AGIPD_SIV1_AGIPDV12_M528","detector_type_id":2,"flg_available":true,"description":null,"created_at":"2023-12-08T12:58:18.000+01:00","updated_at":"2024-07-05T12:31:00.000+02:00","karabo_da":"AGIPD05","detector_id":2,"virtual_device_name":"Q2M2","uuid":102073100000,"float_uuid":5.04308120745e-313,"module_number":null,"karabo_da_at_ccv_begin_at":"AGIPD07","detector_id_at_ccv_begin_at":2,"virtual_device_name_at_ccv_begin_at":"Q2M4","module_number_at_ccv_begin_at":null}},{"id":201639,"name":"20240425_151923_sIdx=0","file_name":"cal.1714058362.009037.h5","path_to_file":"xfel/cal/agipd-type/agipd_siv1_agipdv12_m528/","data_set_name":"/AGIPD_SIV1_AGIPDV12_M528/SlopesCS/0","flg_deployed":true,"flg_good_quality":true,"begin_validity_at":"2023-12-15T17:21:07.000+01:00","end_validity_at":null,"begin_at":"2023-12-15T17:21:07.000+01:00","start_idx":0,"end_idx":0,"raw_data_location":"Proposal:
+        p900376, Run: 264","report_id":null,"description":"","created_at":"2024-04-25T17:19:23.000+02:00","view_url":"https://in.xfel.eu/calibration/calibration_constant_versions/201639","calibration_constant":{"id":33902,"name":"AGIPD-Type_SlopesCS_AGIPD
+        Defuxrj+sznxr52f7KH5KsCkw==\n-2","detector_type_id":2,"calibration_id":52,"condition_id":10974,"flg_auto_approve":true,"flg_available":true,"description":"\n                Constants
+        are saved with the following notation:\n                  - Slopes:\n                    -
+        mH: high gain slope\n                    - mM: medium gain slope\n                    -
+        mL: low gain slope\n                  - Intercepts:\n                    -
+        bH: high gain intercept\n                    - bM: medium gain intercept\n                    -
+        bL: low gain intercept\n                  - Ratios:\n                    -
+        H-M: ratio of high gain and medium gain slope\n                    - M-L:
+        ratio of medium gain and low gain slope\n                ","created_at":"2023-10-20T13:29:12.000+02:00","updated_at":"2025-11-28T09:54:59.000+01:00"},"physical_detector_unit":{"id":224,"physical_name":"AGIPD_SIV1_AGIPDV12_M528","detector_type_id":2,"flg_available":true,"description":null,"created_at":"2023-12-08T12:58:18.000+01:00","updated_at":"2024-07-05T12:31:00.000+02:00","karabo_da":"AGIPD05","detector_id":2,"virtual_device_name":"Q2M2","uuid":102073100000,"float_uuid":5.04308120745e-313,"module_number":null,"karabo_da_at_ccv_begin_at":"AGIPD07","detector_id_at_ccv_begin_at":2,"virtual_device_name_at_ccv_begin_at":"Q2M4","module_number_at_ccv_begin_at":null}},{"id":207716,"name":"20240531_071420_sIdx=0","file_name":"cal.1717139659.3086565.h5","path_to_file":"xfel/cal/agipd-type/agipd_siv1_agipdv12_m412/","data_set_name":"/AGIPD_SIV1_AGIPDV12_M412/BadPixelsCS/0","flg_deployed":true,"flg_good_quality":true,"begin_validity_at":"2023-12-15T17:21:07.000+01:00","end_validity_at":null,"begin_at":"2023-12-15T17:21:07.000+01:00","start_idx":0,"end_idx":0,"raw_data_location":"Proposal:
+        p900376, Run: 264","report_id":null,"description":"","created_at":"2024-05-31T09:14:20.000+02:00","view_url":"https://in.xfel.eu/calibration/calibration_constant_versions/207716","calibration_constant":{"id":33903,"name":"AGIPD-Type_BadPixelsCS_AGIPD
+        Defuxrj+sznxr52f7KH5KsCkw==\n-2","detector_type_id":2,"calibration_id":53,"condition_id":10974,"flg_auto_approve":true,"flg_available":true,"description":"Per-pixel
+        (per-memory cell) bad pixels from CS runs","created_at":"2023-10-20T13:29:17.000+02:00","updated_at":"2025-11-28T09:55:00.000+01:00"},"physical_detector_unit":{"id":225,"physical_name":"AGIPD_SIV1_AGIPDV12_M412","detector_type_id":2,"flg_available":true,"description":null,"created_at":"2023-12-08T12:59:32.000+01:00","updated_at":"2023-12-08T13:10:29.000+01:00","karabo_da":"AGIPD08","detector_id":2,"virtual_device_name":"Q3M1","uuid":102083100000,"float_uuid":5.0435752731e-313,"module_number":null,"karabo_da_at_ccv_begin_at":"AGIPD08","detector_id_at_ccv_begin_at":2,"virtual_device_name_at_ccv_begin_at":"Q3M1","module_number_at_ccv_begin_at":null}},{"id":201641,"name":"20240425_151931_sIdx=0","file_name":"cal.1714058370.0426712.h5","path_to_file":"xfel/cal/agipd-type/agipd_siv1_agipdv12_m412/","data_set_name":"/AGIPD_SIV1_AGIPDV12_M412/SlopesCS/0","flg_deployed":true,"flg_good_quality":true,"begin_validity_at":"2023-12-15T17:21:07.000+01:00","end_validity_at":null,"begin_at":"2023-12-15T17:21:07.000+01:00","start_idx":0,"end_idx":0,"raw_data_location":"Proposal:
+        p900376, Run: 264","report_id":null,"description":"","created_at":"2024-04-25T17:19:31.000+02:00","view_url":"https://in.xfel.eu/calibration/calibration_constant_versions/201641","calibration_constant":{"id":33902,"name":"AGIPD-Type_SlopesCS_AGIPD
+        Defuxrj+sznxr52f7KH5KsCkw==\n-2","detector_type_id":2,"calibration_id":52,"condition_id":10974,"flg_auto_approve":true,"flg_available":true,"description":"\n                Constants
+        are saved with the following notation:\n                  - Slopes:\n                    -
+        mH: high gain slope\n                    - mM: medium gain slope\n                    -
+        mL: low gain slope\n                  - Intercepts:\n                    -
+        bH: high gain intercept\n                    - bM: medium gain intercept\n                    -
+        bL: low gain intercept\n                  - Ratios:\n                    -
+        H-M: ratio of high gain and medium gain slope\n                    - M-L:
+        ratio of medium gain and low gain slope\n                ","created_at":"2023-10-20T13:29:12.000+02:00","updated_at":"2025-11-28T09:54:59.000+01:00"},"physical_detector_unit":{"id":225,"physical_name":"AGIPD_SIV1_AGIPDV12_M412","detector_type_id":2,"flg_available":true,"description":null,"created_at":"2023-12-08T12:59:32.000+01:00","updated_at":"2023-12-08T13:10:29.000+01:00","karabo_da":"AGIPD08","detector_id":2,"virtual_device_name":"Q3M1","uuid":102083100000,"float_uuid":5.0435752731e-313,"module_number":null,"karabo_da_at_ccv_begin_at":"AGIPD08","detector_id_at_ccv_begin_at":2,"virtual_device_name_at_ccv_begin_at":"Q3M1","module_number_at_ccv_begin_at":null}},{"id":207717,"name":"20240531_071426_sIdx=0","file_name":"cal.1717139665.1687832.h5","path_to_file":"xfel/cal/agipd-type/agipd_siv1_agipdv12_m542/","data_set_name":"/AGIPD_SIV1_AGIPDV12_M542/BadPixelsCS/0","flg_deployed":true,"flg_good_quality":true,"begin_validity_at":"2023-12-15T17:21:07.000+01:00","end_validity_at":null,"begin_at":"2023-12-15T17:21:07.000+01:00","start_idx":0,"end_idx":0,"raw_data_location":"Proposal:
+        p900376, Run: 264","report_id":null,"description":"","created_at":"2024-05-31T09:14:26.000+02:00","view_url":"https://in.xfel.eu/calibration/calibration_constant_versions/207717","calibration_constant":{"id":33903,"name":"AGIPD-Type_BadPixelsCS_AGIPD
+        Defuxrj+sznxr52f7KH5KsCkw==\n-2","detector_type_id":2,"calibration_id":53,"condition_id":10974,"flg_auto_approve":true,"flg_available":true,"description":"Per-pixel
+        (per-memory cell) bad pixels from CS runs","created_at":"2023-10-20T13:29:17.000+02:00","updated_at":"2025-11-28T09:55:00.000+01:00"},"physical_detector_unit":{"id":226,"physical_name":"AGIPD_SIV1_AGIPDV12_M542","detector_type_id":2,"flg_available":true,"description":null,"created_at":"2023-12-08T13:00:05.000+01:00","updated_at":"2023-12-08T13:10:29.000+01:00","karabo_da":"AGIPD09","detector_id":2,"virtual_device_name":"Q3M2","uuid":102093100000,"float_uuid":5.04406933874e-313,"module_number":null,"karabo_da_at_ccv_begin_at":"AGIPD09","detector_id_at_ccv_begin_at":2,"virtual_device_name_at_ccv_begin_at":"Q3M2","module_number_at_ccv_begin_at":null}},{"id":201643,"name":"20240425_151939_sIdx=0","file_name":"cal.1714058378.0507371.h5","path_to_file":"xfel/cal/agipd-type/agipd_siv1_agipdv12_m542/","data_set_name":"/AGIPD_SIV1_AGIPDV12_M542/SlopesCS/0","flg_deployed":true,"flg_good_quality":true,"begin_validity_at":"2023-12-15T17:21:07.000+01:00","end_validity_at":null,"begin_at":"2023-12-15T17:21:07.000+01:00","start_idx":0,"end_idx":0,"raw_data_location":"Proposal:
+        p900376, Run: 264","report_id":null,"description":"","created_at":"2024-04-25T17:19:39.000+02:00","view_url":"https://in.xfel.eu/calibration/calibration_constant_versions/201643","calibration_constant":{"id":33902,"name":"AGIPD-Type_SlopesCS_AGIPD
+        Defuxrj+sznxr52f7KH5KsCkw==\n-2","detector_type_id":2,"calibration_id":52,"condition_id":10974,"flg_auto_approve":true,"flg_available":true,"description":"\n                Constants
+        are saved with the following notation:\n                  - Slopes:\n                    -
+        mH: high gain slope\n                    - mM: medium gain slope\n                    -
+        mL: low gain slope\n                  - Intercepts:\n                    -
+        bH: high gain intercept\n                    - bM: medium gain intercept\n                    -
+        bL: low gain intercept\n                  - Ratios:\n                    -
+        H-M: ratio of high gain and medium gain slope\n                    - M-L:
+        ratio of medium gain and low gain slope\n                ","created_at":"2023-10-20T13:29:12.000+02:00","updated_at":"2025-11-28T09:54:59.000+01:00"},"physical_detector_unit":{"id":226,"physical_name":"AGIPD_SIV1_AGIPDV12_M542","detector_type_id":2,"flg_available":true,"description":null,"created_at":"2023-12-08T13:00:05.000+01:00","updated_at":"2023-12-08T13:10:29.000+01:00","karabo_da":"AGIPD09","detector_id":2,"virtual_device_name":"Q3M2","uuid":102093100000,"float_uuid":5.04406933874e-313,"module_number":null,"karabo_da_at_ccv_begin_at":"AGIPD09","detector_id_at_ccv_begin_at":2,"virtual_device_name_at_ccv_begin_at":"Q3M2","module_number_at_ccv_begin_at":null}},{"id":207718,"name":"20240531_071432_sIdx=0","file_name":"cal.1717139671.094016.h5","path_to_file":"xfel/cal/agipd-type/agipd_siv1_agipdv12_m527/","data_set_name":"/AGIPD_SIV1_AGIPDV12_M527/BadPixelsCS/0","flg_deployed":true,"flg_good_quality":true,"begin_validity_at":"2023-12-15T17:21:07.000+01:00","end_validity_at":null,"begin_at":"2023-12-15T17:21:07.000+01:00","start_idx":0,"end_idx":0,"raw_data_location":"Proposal:
+        p900376, Run: 264","report_id":null,"description":"","created_at":"2024-05-31T09:14:32.000+02:00","view_url":"https://in.xfel.eu/calibration/calibration_constant_versions/207718","calibration_constant":{"id":33903,"name":"AGIPD-Type_BadPixelsCS_AGIPD
+        Defuxrj+sznxr52f7KH5KsCkw==\n-2","detector_type_id":2,"calibration_id":53,"condition_id":10974,"flg_auto_approve":true,"flg_available":true,"description":"Per-pixel
+        (per-memory cell) bad pixels from CS runs","created_at":"2023-10-20T13:29:17.000+02:00","updated_at":"2025-11-28T09:55:00.000+01:00"},"physical_detector_unit":{"id":227,"physical_name":"AGIPD_SIV1_AGIPDV12_M527","detector_type_id":2,"flg_available":true,"description":null,"created_at":"2023-12-08T13:00:50.000+01:00","updated_at":"2023-12-08T13:10:29.000+01:00","karabo_da":"AGIPD10","detector_id":2,"virtual_device_name":"Q3M3","uuid":102103100000,"float_uuid":5.0445634044e-313,"module_number":null,"karabo_da_at_ccv_begin_at":"AGIPD10","detector_id_at_ccv_begin_at":2,"virtual_device_name_at_ccv_begin_at":"Q3M3","module_number_at_ccv_begin_at":null}},{"id":201645,"name":"20240425_151947_sIdx=0","file_name":"cal.1714058386.2358193.h5","path_to_file":"xfel/cal/agipd-type/agipd_siv1_agipdv12_m527/","data_set_name":"/AGIPD_SIV1_AGIPDV12_M527/SlopesCS/0","flg_deployed":true,"flg_good_quality":true,"begin_validity_at":"2023-12-15T17:21:07.000+01:00","end_validity_at":null,"begin_at":"2023-12-15T17:21:07.000+01:00","start_idx":0,"end_idx":0,"raw_data_location":"Proposal:
+        p900376, Run: 264","report_id":null,"description":"","created_at":"2024-04-25T17:19:47.000+02:00","view_url":"https://in.xfel.eu/calibration/calibration_constant_versions/201645","calibration_constant":{"id":33902,"name":"AGIPD-Type_SlopesCS_AGIPD
+        Defuxrj+sznxr52f7KH5KsCkw==\n-2","detector_type_id":2,"calibration_id":52,"condition_id":10974,"flg_auto_approve":true,"flg_available":true,"description":"\n                Constants
+        are saved with the following notation:\n                  - Slopes:\n                    -
+        mH: high gain slope\n                    - mM: medium gain slope\n                    -
+        mL: low gain slope\n                  - Intercepts:\n                    -
+        bH: high gain intercept\n                    - bM: medium gain intercept\n                    -
+        bL: low gain intercept\n                  - Ratios:\n                    -
+        H-M: ratio of high gain and medium gain slope\n                    - M-L:
+        ratio of medium gain and low gain slope\n                ","created_at":"2023-10-20T13:29:12.000+02:00","updated_at":"2025-11-28T09:54:59.000+01:00"},"physical_detector_unit":{"id":227,"physical_name":"AGIPD_SIV1_AGIPDV12_M527","detector_type_id":2,"flg_available":true,"description":null,"created_at":"2023-12-08T13:00:50.000+01:00","updated_at":"2023-12-08T13:10:29.000+01:00","karabo_da":"AGIPD10","detector_id":2,"virtual_device_name":"Q3M3","uuid":102103100000,"float_uuid":5.0445634044e-313,"module_number":null,"karabo_da_at_ccv_begin_at":"AGIPD10","detector_id_at_ccv_begin_at":2,"virtual_device_name_at_ccv_begin_at":"Q3M3","module_number_at_ccv_begin_at":null}},{"id":207719,"name":"20240531_071437_sIdx=0","file_name":"cal.1717139676.9327195.h5","path_to_file":"xfel/cal/agipd-type/agipd_siv1_agipdv12_m502/","data_set_name":"/AGIPD_SIV1_AGIPDV12_M502/BadPixelsCS/0","flg_deployed":true,"flg_good_quality":true,"begin_validity_at":"2023-12-15T17:21:07.000+01:00","end_validity_at":null,"begin_at":"2023-12-15T17:21:07.000+01:00","start_idx":0,"end_idx":0,"raw_data_location":"Proposal:
+        p900376, Run: 264","report_id":null,"description":"","created_at":"2024-05-31T09:14:37.000+02:00","view_url":"https://in.xfel.eu/calibration/calibration_constant_versions/207719","calibration_constant":{"id":33903,"name":"AGIPD-Type_BadPixelsCS_AGIPD
+        Defuxrj+sznxr52f7KH5KsCkw==\n-2","detector_type_id":2,"calibration_id":53,"condition_id":10974,"flg_auto_approve":true,"flg_available":true,"description":"Per-pixel
+        (per-memory cell) bad pixels from CS runs","created_at":"2023-10-20T13:29:17.000+02:00","updated_at":"2025-11-28T09:55:00.000+01:00"},"physical_detector_unit":{"id":228,"physical_name":"AGIPD_SIV1_AGIPDV12_M502","detector_type_id":2,"flg_available":true,"description":null,"created_at":"2023-12-08T13:01:17.000+01:00","updated_at":"2023-12-08T13:10:29.000+01:00","karabo_da":"AGIPD11","detector_id":2,"virtual_device_name":"Q3M4","uuid":102113100000,"float_uuid":5.04505747004e-313,"module_number":null,"karabo_da_at_ccv_begin_at":"AGIPD11","detector_id_at_ccv_begin_at":2,"virtual_device_name_at_ccv_begin_at":"Q3M4","module_number_at_ccv_begin_at":null}},{"id":201647,"name":"20240425_151955_sIdx=0","file_name":"cal.1714058394.3945415.h5","path_to_file":"xfel/cal/agipd-type/agipd_siv1_agipdv12_m502/","data_set_name":"/AGIPD_SIV1_AGIPDV12_M502/SlopesCS/0","flg_deployed":true,"flg_good_quality":true,"begin_validity_at":"2023-12-15T17:21:07.000+01:00","end_validity_at":null,"begin_at":"2023-12-15T17:21:07.000+01:00","start_idx":0,"end_idx":0,"raw_data_location":"Proposal:
+        p900376, Run: 264","report_id":null,"description":"","created_at":"2024-04-25T17:19:55.000+02:00","view_url":"https://in.xfel.eu/calibration/calibration_constant_versions/201647","calibration_constant":{"id":33902,"name":"AGIPD-Type_SlopesCS_AGIPD
+        Defuxrj+sznxr52f7KH5KsCkw==\n-2","detector_type_id":2,"calibration_id":52,"condition_id":10974,"flg_auto_approve":true,"flg_available":true,"description":"\n                Constants
+        are saved with the following notation:\n                  - Slopes:\n                    -
+        mH: high gain slope\n                    - mM: medium gain slope\n                    -
+        mL: low gain slope\n                  - Intercepts:\n                    -
+        bH: high gain intercept\n                    - bM: medium gain intercept\n                    -
+        bL: low gain intercept\n                  - Ratios:\n                    -
+        H-M: ratio of high gain and medium gain slope\n                    - M-L:
+        ratio of medium gain and low gain slope\n                ","created_at":"2023-10-20T13:29:12.000+02:00","updated_at":"2025-11-28T09:54:59.000+01:00"},"physical_detector_unit":{"id":228,"physical_name":"AGIPD_SIV1_AGIPDV12_M502","detector_type_id":2,"flg_available":true,"description":null,"created_at":"2023-12-08T13:01:17.000+01:00","updated_at":"2023-12-08T13:10:29.000+01:00","karabo_da":"AGIPD11","detector_id":2,"virtual_device_name":"Q3M4","uuid":102113100000,"float_uuid":5.04505747004e-313,"module_number":null,"karabo_da_at_ccv_begin_at":"AGIPD11","detector_id_at_ccv_begin_at":2,"virtual_device_name_at_ccv_begin_at":"Q3M4","module_number_at_ccv_begin_at":null}},{"id":207720,"name":"20240531_071443_sIdx=0","file_name":"cal.1717139682.665947.h5","path_to_file":"xfel/cal/agipd-type/agipd_siv1_agipdv12_m426/","data_set_name":"/AGIPD_SIV1_AGIPDV12_M426/BadPixelsCS/0","flg_deployed":true,"flg_good_quality":true,"begin_validity_at":"2023-12-15T17:21:07.000+01:00","end_validity_at":null,"begin_at":"2023-12-15T17:21:07.000+01:00","start_idx":0,"end_idx":0,"raw_data_location":"Proposal:
+        p900376, Run: 264","report_id":null,"description":"","created_at":"2024-05-31T09:14:43.000+02:00","view_url":"https://in.xfel.eu/calibration/calibration_constant_versions/207720","calibration_constant":{"id":33903,"name":"AGIPD-Type_BadPixelsCS_AGIPD
+        Defuxrj+sznxr52f7KH5KsCkw==\n-2","detector_type_id":2,"calibration_id":53,"condition_id":10974,"flg_auto_approve":true,"flg_available":true,"description":"Per-pixel
+        (per-memory cell) bad pixels from CS runs","created_at":"2023-10-20T13:29:17.000+02:00","updated_at":"2025-11-28T09:55:00.000+01:00"},"physical_detector_unit":{"id":229,"physical_name":"AGIPD_SIV1_AGIPDV12_M426","detector_type_id":2,"flg_available":true,"description":null,"created_at":"2023-12-08T13:01:55.000+01:00","updated_at":"2023-12-08T13:10:29.000+01:00","karabo_da":"AGIPD12","detector_id":2,"virtual_device_name":"Q4M1","uuid":102123100000,"float_uuid":5.0455515357e-313,"module_number":null,"karabo_da_at_ccv_begin_at":"AGIPD12","detector_id_at_ccv_begin_at":2,"virtual_device_name_at_ccv_begin_at":"Q4M1","module_number_at_ccv_begin_at":null}},{"id":201649,"name":"20240425_152004_sIdx=0","file_name":"cal.1714058403.422137.h5","path_to_file":"xfel/cal/agipd-type/agipd_siv1_agipdv12_m426/","data_set_name":"/AGIPD_SIV1_AGIPDV12_M426/SlopesCS/0","flg_deployed":true,"flg_good_quality":true,"begin_validity_at":"2023-12-15T17:21:07.000+01:00","end_validity_at":null,"begin_at":"2023-12-15T17:21:07.000+01:00","start_idx":0,"end_idx":0,"raw_data_location":"Proposal:
+        p900376, Run: 264","report_id":null,"description":"","created_at":"2024-04-25T17:20:04.000+02:00","view_url":"https://in.xfel.eu/calibration/calibration_constant_versions/201649","calibration_constant":{"id":33902,"name":"AGIPD-Type_SlopesCS_AGIPD
+        Defuxrj+sznxr52f7KH5KsCkw==\n-2","detector_type_id":2,"calibration_id":52,"condition_id":10974,"flg_auto_approve":true,"flg_available":true,"description":"\n                Constants
+        are saved with the following notation:\n                  - Slopes:\n                    -
+        mH: high gain slope\n                    - mM: medium gain slope\n                    -
+        mL: low gain slope\n                  - Intercepts:\n                    -
+        bH: high gain intercept\n                    - bM: medium gain intercept\n                    -
+        bL: low gain intercept\n                  - Ratios:\n                    -
+        H-M: ratio of high gain and medium gain slope\n                    - M-L:
+        ratio of medium gain and low gain slope\n                ","created_at":"2023-10-20T13:29:12.000+02:00","updated_at":"2025-11-28T09:54:59.000+01:00"},"physical_detector_unit":{"id":229,"physical_name":"AGIPD_SIV1_AGIPDV12_M426","detector_type_id":2,"flg_available":true,"description":null,"created_at":"2023-12-08T13:01:55.000+01:00","updated_at":"2023-12-08T13:10:29.000+01:00","karabo_da":"AGIPD12","detector_id":2,"virtual_device_name":"Q4M1","uuid":102123100000,"float_uuid":5.0455515357e-313,"module_number":null,"karabo_da_at_ccv_begin_at":"AGIPD12","detector_id_at_ccv_begin_at":2,"virtual_device_name_at_ccv_begin_at":"Q4M1","module_number_at_ccv_begin_at":null}},{"id":207721,"name":"20240531_071449_sIdx=0","file_name":"cal.1717139688.326113.h5","path_to_file":"xfel/cal/agipd-type/agipd_siv1_agipdv12_m540/","data_set_name":"/AGIPD_SIV1_AGIPDV12_M540/BadPixelsCS/0","flg_deployed":true,"flg_good_quality":true,"begin_validity_at":"2023-12-15T17:21:07.000+01:00","end_validity_at":null,"begin_at":"2023-12-15T17:21:07.000+01:00","start_idx":0,"end_idx":0,"raw_data_location":"Proposal:
+        p900376, Run: 264","report_id":null,"description":"","created_at":"2024-05-31T09:14:49.000+02:00","view_url":"https://in.xfel.eu/calibration/calibration_constant_versions/207721","calibration_constant":{"id":33903,"name":"AGIPD-Type_BadPixelsCS_AGIPD
+        Defuxrj+sznxr52f7KH5KsCkw==\n-2","detector_type_id":2,"calibration_id":53,"condition_id":10974,"flg_auto_approve":true,"flg_available":true,"description":"Per-pixel
+        (per-memory cell) bad pixels from CS runs","created_at":"2023-10-20T13:29:17.000+02:00","updated_at":"2025-11-28T09:55:00.000+01:00"},"physical_detector_unit":{"id":230,"physical_name":"AGIPD_SIV1_AGIPDV12_M540","detector_type_id":2,"flg_available":true,"description":null,"created_at":"2023-12-08T13:02:31.000+01:00","updated_at":"2023-12-08T13:10:29.000+01:00","karabo_da":"AGIPD13","detector_id":2,"virtual_device_name":"Q4M2","uuid":102133100000,"float_uuid":5.04604560133e-313,"module_number":null,"karabo_da_at_ccv_begin_at":"AGIPD13","detector_id_at_ccv_begin_at":2,"virtual_device_name_at_ccv_begin_at":"Q4M2","module_number_at_ccv_begin_at":null}},{"id":201651,"name":"20240425_152012_sIdx=0","file_name":"cal.1714058411.6757722.h5","path_to_file":"xfel/cal/agipd-type/agipd_siv1_agipdv12_m540/","data_set_name":"/AGIPD_SIV1_AGIPDV12_M540/SlopesCS/0","flg_deployed":true,"flg_good_quality":true,"begin_validity_at":"2023-12-15T17:21:07.000+01:00","end_validity_at":null,"begin_at":"2023-12-15T17:21:07.000+01:00","start_idx":0,"end_idx":0,"raw_data_location":"Proposal:
+        p900376, Run: 264","report_id":null,"description":"","created_at":"2024-04-25T17:20:12.000+02:00","view_url":"https://in.xfel.eu/calibration/calibration_constant_versions/201651","calibration_constant":{"id":33902,"name":"AGIPD-Type_SlopesCS_AGIPD
+        Defuxrj+sznxr52f7KH5KsCkw==\n-2","detector_type_id":2,"calibration_id":52,"condition_id":10974,"flg_auto_approve":true,"flg_available":true,"description":"\n                Constants
+        are saved with the following notation:\n                  - Slopes:\n                    -
+        mH: high gain slope\n                    - mM: medium gain slope\n                    -
+        mL: low gain slope\n                  - Intercepts:\n                    -
+        bH: high gain intercept\n                    - bM: medium gain intercept\n                    -
+        bL: low gain intercept\n                  - Ratios:\n                    -
+        H-M: ratio of high gain and medium gain slope\n                    - M-L:
+        ratio of medium gain and low gain slope\n                ","created_at":"2023-10-20T13:29:12.000+02:00","updated_at":"2025-11-28T09:54:59.000+01:00"},"physical_detector_unit":{"id":230,"physical_name":"AGIPD_SIV1_AGIPDV12_M540","detector_type_id":2,"flg_available":true,"description":null,"created_at":"2023-12-08T13:02:31.000+01:00","updated_at":"2023-12-08T13:10:29.000+01:00","karabo_da":"AGIPD13","detector_id":2,"virtual_device_name":"Q4M2","uuid":102133100000,"float_uuid":5.04604560133e-313,"module_number":null,"karabo_da_at_ccv_begin_at":"AGIPD13","detector_id_at_ccv_begin_at":2,"virtual_device_name_at_ccv_begin_at":"Q4M2","module_number_at_ccv_begin_at":null}},{"id":207722,"name":"20240531_071455_sIdx=0","file_name":"cal.1717139694.0458565.h5","path_to_file":"xfel/cal/agipd-type/agipd_siv1_agipdv12_m515/","data_set_name":"/AGIPD_SIV1_AGIPDV12_M515/BadPixelsCS/0","flg_deployed":true,"flg_good_quality":true,"begin_validity_at":"2023-12-15T17:21:07.000+01:00","end_validity_at":null,"begin_at":"2023-12-15T17:21:07.000+01:00","start_idx":0,"end_idx":0,"raw_data_location":"Proposal:
+        p900376, Run: 264","report_id":null,"description":"","created_at":"2024-05-31T09:14:55.000+02:00","view_url":"https://in.xfel.eu/calibration/calibration_constant_versions/207722","calibration_constant":{"id":33903,"name":"AGIPD-Type_BadPixelsCS_AGIPD
+        Defuxrj+sznxr52f7KH5KsCkw==\n-2","detector_type_id":2,"calibration_id":53,"condition_id":10974,"flg_auto_approve":true,"flg_available":true,"description":"Per-pixel
+        (per-memory cell) bad pixels from CS runs","created_at":"2023-10-20T13:29:17.000+02:00","updated_at":"2025-11-28T09:55:00.000+01:00"},"physical_detector_unit":{"id":231,"physical_name":"AGIPD_SIV1_AGIPDV12_M515","detector_type_id":2,"flg_available":true,"description":null,"created_at":"2023-12-08T13:03:06.000+01:00","updated_at":"2023-12-08T13:10:29.000+01:00","karabo_da":"AGIPD14","detector_id":2,"virtual_device_name":"Q4M3","uuid":102143100000,"float_uuid":5.04653966697e-313,"module_number":null,"karabo_da_at_ccv_begin_at":"AGIPD14","detector_id_at_ccv_begin_at":2,"virtual_device_name_at_ccv_begin_at":"Q4M3","module_number_at_ccv_begin_at":null}},{"id":201653,"name":"20240425_152021_sIdx=0","file_name":"cal.1714058419.8910336.h5","path_to_file":"xfel/cal/agipd-type/agipd_siv1_agipdv12_m515/","data_set_name":"/AGIPD_SIV1_AGIPDV12_M515/SlopesCS/0","flg_deployed":true,"flg_good_quality":true,"begin_validity_at":"2023-12-15T17:21:07.000+01:00","end_validity_at":null,"begin_at":"2023-12-15T17:21:07.000+01:00","start_idx":0,"end_idx":0,"raw_data_location":"Proposal:
+        p900376, Run: 264","report_id":null,"description":"","created_at":"2024-04-25T17:20:21.000+02:00","view_url":"https://in.xfel.eu/calibration/calibration_constant_versions/201653","calibration_constant":{"id":33902,"name":"AGIPD-Type_SlopesCS_AGIPD
+        Defuxrj+sznxr52f7KH5KsCkw==\n-2","detector_type_id":2,"calibration_id":52,"condition_id":10974,"flg_auto_approve":true,"flg_available":true,"description":"\n                Constants
+        are saved with the following notation:\n                  - Slopes:\n                    -
+        mH: high gain slope\n                    - mM: medium gain slope\n                    -
+        mL: low gain slope\n                  - Intercepts:\n                    -
+        bH: high gain intercept\n                    - bM: medium gain intercept\n                    -
+        bL: low gain intercept\n                  - Ratios:\n                    -
+        H-M: ratio of high gain and medium gain slope\n                    - M-L:
+        ratio of medium gain and low gain slope\n                ","created_at":"2023-10-20T13:29:12.000+02:00","updated_at":"2025-11-28T09:54:59.000+01:00"},"physical_detector_unit":{"id":231,"physical_name":"AGIPD_SIV1_AGIPDV12_M515","detector_type_id":2,"flg_available":true,"description":null,"created_at":"2023-12-08T13:03:06.000+01:00","updated_at":"2023-12-08T13:10:29.000+01:00","karabo_da":"AGIPD14","detector_id":2,"virtual_device_name":"Q4M3","uuid":102143100000,"float_uuid":5.04653966697e-313,"module_number":null,"karabo_da_at_ccv_begin_at":"AGIPD14","detector_id_at_ccv_begin_at":2,"virtual_device_name_at_ccv_begin_at":"Q4M3","module_number_at_ccv_begin_at":null}},{"id":207723,"name":"20240531_071500_sIdx=0","file_name":"cal.1717139699.9212859.h5","path_to_file":"xfel/cal/agipd-type/agipd_siv1_agipdv12_m544/","data_set_name":"/AGIPD_SIV1_AGIPDV12_M544/BadPixelsCS/0","flg_deployed":true,"flg_good_quality":true,"begin_validity_at":"2023-12-15T17:21:07.000+01:00","end_validity_at":null,"begin_at":"2023-12-15T17:21:07.000+01:00","start_idx":0,"end_idx":0,"raw_data_location":"Proposal:
+        p900376, Run: 264","report_id":null,"description":"","created_at":"2024-05-31T09:15:00.000+02:00","view_url":"https://in.xfel.eu/calibration/calibration_constant_versions/207723","calibration_constant":{"id":33903,"name":"AGIPD-Type_BadPixelsCS_AGIPD
+        Defuxrj+sznxr52f7KH5KsCkw==\n-2","detector_type_id":2,"calibration_id":53,"condition_id":10974,"flg_auto_approve":true,"flg_available":true,"description":"Per-pixel
+        (per-memory cell) bad pixels from CS runs","created_at":"2023-10-20T13:29:17.000+02:00","updated_at":"2025-11-28T09:55:00.000+01:00"},"physical_detector_unit":{"id":232,"physical_name":"AGIPD_SIV1_AGIPDV12_M544","detector_type_id":2,"flg_available":true,"description":null,"created_at":"2023-12-08T13:03:40.000+01:00","updated_at":"2023-12-08T13:10:29.000+01:00","karabo_da":"AGIPD15","detector_id":2,"virtual_device_name":"Q4M4","uuid":102153100000,"float_uuid":5.0470337326e-313,"module_number":null,"karabo_da_at_ccv_begin_at":"AGIPD15","detector_id_at_ccv_begin_at":2,"virtual_device_name_at_ccv_begin_at":"Q4M4","module_number_at_ccv_begin_at":null}},{"id":201655,"name":"20240425_152029_sIdx=0","file_name":"cal.1714058428.1514454.h5","path_to_file":"xfel/cal/agipd-type/agipd_siv1_agipdv12_m544/","data_set_name":"/AGIPD_SIV1_AGIPDV12_M544/SlopesCS/0","flg_deployed":true,"flg_good_quality":true,"begin_validity_at":"2023-12-15T17:21:07.000+01:00","end_validity_at":null,"begin_at":"2023-12-15T17:21:07.000+01:00","start_idx":0,"end_idx":0,"raw_data_location":"Proposal:
+        p900376, Run: 264","report_id":null,"description":"","created_at":"2024-04-25T17:20:29.000+02:00","view_url":"https://in.xfel.eu/calibration/calibration_constant_versions/201655","calibration_constant":{"id":33902,"name":"AGIPD-Type_SlopesCS_AGIPD
+        Defuxrj+sznxr52f7KH5KsCkw==\n-2","detector_type_id":2,"calibration_id":52,"condition_id":10974,"flg_auto_approve":true,"flg_available":true,"description":"\n                Constants
+        are saved with the following notation:\n                  - Slopes:\n                    -
+        mH: high gain slope\n                    - mM: medium gain slope\n                    -
+        mL: low gain slope\n                  - Intercepts:\n                    -
+        bH: high gain intercept\n                    - bM: medium gain intercept\n                    -
+        bL: low gain intercept\n                  - Ratios:\n                    -
+        H-M: ratio of high gain and medium gain slope\n                    - M-L:
+        ratio of medium gain and low gain slope\n                ","created_at":"2023-10-20T13:29:12.000+02:00","updated_at":"2025-11-28T09:54:59.000+01:00"},"physical_detector_unit":{"id":232,"physical_name":"AGIPD_SIV1_AGIPDV12_M544","detector_type_id":2,"flg_available":true,"description":null,"created_at":"2023-12-08T13:03:40.000+01:00","updated_at":"2023-12-08T13:10:29.000+01:00","karabo_da":"AGIPD15","detector_id":2,"virtual_device_name":"Q4M4","uuid":102153100000,"float_uuid":5.0470337326e-313,"module_number":null,"karabo_da_at_ccv_begin_at":"AGIPD15","detector_id_at_ccv_begin_at":2,"virtual_device_name_at_ccv_begin_at":"Q4M4","module_number_at_ccv_begin_at":null}}]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '42259'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 10 Apr 2026 10:09:21 GMT
+      Etag:
+      - W/"33b0fb1f7517fef97454bd6e6ec6b1bc"
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=16070400; includeSubDomains
+      Vary:
+      - Origin
+      Via:
+      - HTTP/1.1 xfel_oauth_proxy
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R)
+      X-Request-Id:
+      - bfd76cf3-580c-400d-8700-808096d1d2ae
+      X-Runtime:
+      - '0.839350'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 
+from datetime import datetime, timezone
 from pathlib import Path
 from shutil import copytree
 from tempfile import TemporaryDirectory
@@ -7,6 +8,7 @@ import h5py
 import numpy as np
 import pytest
 from extra_data import RunDirectory
+from extra_data.tests import make_examples
 from extra_data.tests.mockdata import write_file
 
 from extra_data.tests.mockdata.motor import Motor
@@ -20,6 +22,7 @@ from .mockdata.timeserver import PulsePatternDecoder, Timeserver
 from .mockdata.xgm import XGM, XGMD, XGMReduced, XGMWithData
 from .mockdata.mono import MonoMdl
 from .mockdata.camera import CameraWithData, GotthardIIWithData
+
 
 @pytest.fixture(scope='session')
 def mock_spb_aux_directory():
@@ -78,9 +81,68 @@ def mock_spb_aux_directory():
         yield td
 
 
+def _patch_train_timestamps(run):
+    ts = datetime(year=2026, month=4, day=10, hour=11, minute=27) \
+        .replace(tzinfo=timezone.utc).timestamp() * 10**9
+
+    for fa in run.files:
+        fa.close()
+        with h5py.File(fa.filename, 'a') as h5f:
+            dset = h5f['INDEX/timestamp']
+            dset[:] = [ts + i * 10**8 for i in range(dset.shape[0])]
+
 @pytest.fixture(scope='function')
 def mock_spb_aux_run(mock_spb_aux_directory):
     yield RunDirectory(mock_spb_aux_directory)
+
+
+@pytest.fixture(scope='session')
+def mock_agipd1m_directory():
+    with TemporaryDirectory() as td:
+        make_examples.make_agipd1m_run(td)
+        yield td
+
+
+@pytest.fixture(scope='function')
+def mock_agipd1m_run(mock_agipd1m_directory):
+    run = RunDirectory(mock_agipd1m_directory)
+    _patch_train_timestamps(run)
+    yield run
+
+
+@pytest.fixture(scope='session')
+def mock_legacy_agipd1m_directory():
+    # No gain.value or bunchStructure.repetitionRate in /CONTROL/
+    with TemporaryDirectory() as td:
+        make_examples.make_agipd1m_run(
+            td, rep_rate=False,
+            gain_setting=False,
+            integration_time=False,
+            bias_voltage=True
+        )
+        yield td
+
+
+@pytest.fixture(scope='function')
+def mock_legacy_agipd1m_run(mock_legacy_agipd1m_directory):
+    run = RunDirectory(mock_legacy_agipd1m_directory)
+    _patch_train_timestamps(run)
+    yield run
+
+
+@pytest.fixture(scope='session')
+def mock_agipd500k_directory():
+    # No gain.value or bunchStructure.repetitionRate in /CONTROL/
+    with TemporaryDirectory() as td:
+        make_examples.make_agipd500k_run(td)
+        yield td
+
+
+@pytest.fixture(scope='function')
+def mock_agipd500k_run(mock_agipd500k_directory):
+    run = RunDirectory(mock_agipd500k_directory)
+    _patch_train_timestamps(run)
+    yield run
 
 
 @pytest.fixture(scope="session")
@@ -168,6 +230,7 @@ def mock_timepix_exceeded_buffer_run(mock_sqs_timepix_directory):
 def mock_etof_calibration_constants():
     yield (623419.734, 946.026, 11.527)
 
+
 @pytest.fixture(scope='session')
 def mock_etof_mono_energies():
     # 200 trains with 10 energies and 20 trains per energy
@@ -176,6 +239,7 @@ def mock_etof_mono_energies():
         energy += [e]*20
     energy = np.array(energy)
     yield energy
+
 
 @pytest.fixture(scope='session')
 def mock_sqs_etof_calibration_directory(mock_etof_mono_energies, mock_etof_calibration_constants):
@@ -228,6 +292,7 @@ def mock_sqs_etof_calibration_directory(mock_etof_mono_energies, mock_etof_calib
                    format_version='1.2')
         yield td
 
+
 @pytest.fixture(scope='session')
 def mock_sqs_grating_calibration_directory():
     #energy = mock_grating_mono_energies()
@@ -270,6 +335,7 @@ def mock_sqs_grating_calibration_directory():
 @pytest.fixture(scope='function')
 def mock_sqs_etof_calibration_run(mock_sqs_etof_calibration_directory):
     yield RunDirectory(mock_sqs_etof_calibration_directory)
+
 
 @pytest.fixture(scope='function')
 def mock_sqs_grating_calibration_run(mock_sqs_grating_calibration_directory):

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -22,6 +22,7 @@ from extra.calibration import (
     SourceNameFormatter,
     get_client,
     lpd_dark_consts_with_fallback,
+    AutoConditionsError
 )
 
 # Most of these tests use saved HTTP responses by default (with pytest-recording).
@@ -519,3 +520,49 @@ def test_lpd_fallback():
     assert cd_chosen2['Offset'].aggregator_names == [f"LPD{m:02}" for m in range(16)]
     params2 = get_retrieved_params(cd_chosen2)
     assert params2['Memory cell order']['txt_value'] == mem_cells
+
+
+@pytest.mark.vcr
+def test_AGIPDConditions_from_data(mock_agipd1m_run, mock_legacy_agipd1m_run,
+                                   mock_agipd500k_run):
+    run = mock_agipd1m_run
+    cond = AGIPDConditions.from_data(run, 'SPB_DET_AGIPD1M-1')
+    assert cond.sensor_bias_voltage == 300
+    assert cond.memory_cells == 0  # Zeroed in FPGA_COMP
+    assert cond.acquisition_rate == 4.5
+    assert cond.integration_time == 15
+    assert cond.gain_setting == 0
+    assert cond.gain_mode == 0
+
+    run = mock_agipd1m_run.select('*:xtdf')  # Select only XTDF data.
+
+    with pytest.raises(AutoConditionsError):
+        # Should fail without more arguments.
+        AGIPDConditions.from_data(run, 'SPB_DET_AGIPD1M-1')
+
+    cond = AGIPDConditions.from_data(run, 'SPB_DET_AGIPD1M-1', gain_mode=1,
+                                     gain_setting=1, sensor_bias_voltage=150)
+    assert cond.sensor_bias_voltage == 150  # Manually set
+    assert cond.memory_cells == 64  # Now from XTDF
+    assert cond.acquisition_rate == 4.5  # Now from XTDF
+    assert cond.integration_time == 12  # Default value
+    assert cond.gain_setting == 1  # Manually set
+    assert cond.gain_mode == 1  # Manually set
+
+    run = mock_legacy_agipd1m_run
+    cond = AGIPDConditions.from_data(run, 'SPB_DET_AGIPD1M-1')
+    assert cond.sensor_bias_voltage == 300
+    assert cond.memory_cells == 0  # Zeroed in FPGA_COMP
+    assert cond.acquisition_rate == 4.5
+    assert cond.gain_setting == 0
+    assert cond.gain_mode == 0
+    assert cond.integration_time == 12
+
+    run = mock_agipd500k_run
+    cond = AGIPDConditions.from_data(run, 'HED_DET_AGIPD500K2G')
+    assert cond.sensor_bias_voltage == 200
+    assert cond.memory_cells == 0  # Zeroed in FPGA_COMP
+    assert cond.acquisition_rate == 4.5
+    assert cond.gain_setting == 0
+    assert cond.gain_mode == 0
+    assert cond.integration_time == 15

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -566,3 +566,10 @@ def test_AGIPDConditions_from_data(mock_agipd1m_run, mock_legacy_agipd1m_run,
     assert cond.gain_setting == 0
     assert cond.gain_mode == 0
     assert cond.integration_time == 15
+
+
+@pytest.mark.vcr
+def test_CalibrationData_from_data(mock_agipd1m_run):
+    caldata = CalibrationData.from_data(mock_agipd1m_run, 'SPB_DET_AGIPD1M-1')
+    assert caldata.detector_name == 'SPB_DET_AGIPD1M-1'
+    assert 'SlopesCS' in caldata


### PR DESCRIPTION
One of the original ideas behind the `CalibrationData` API is to integrate the determination of detector condition from data, i.e. the various properties of control devices and/or the data itself. Due to various changes over the years to hardware and/or software, this can unfortunately be somewhat messy and is nowadays encoded in calibration notebooks, amongst other places.

This is an attempt to bring this functionality to the `CalibrationData` API in EXtra. Ideally, it makes obtaining calibration data as simply as:

```python
run = open_run(...)
cd = CalibrationData.from_data(run)
```

As it happens, the new design lends itself to this quite nicely by separating the detector-specific and -agnostic parts as before across the `CalibrationData` class and `ConditionsBase` implementation:

- Each detector-specific `ConditionsBase` object gains a `.from_data()` class method taking an `extra_data.DataCollection` as well as the CalCat detector name. From that, it attempts to initialize itself by inferring the necessary fields from the data. For `AGIPDConditions` e.g., its signature is:

  ```python
  @classmethod
  def from_data(cls, data, detector_name, modules=None,
                fpga_comp=None, mpod=None, fpga_control=None, xtdf=None,
                client=None, **params):
  ```
  `fpga_comp`, `mpod`, `fpga_control`, `xtdf` are inferred from the detector entry in CalCat and what's in `data`, or can be overwritten manually. The same applies to the `modules` list, which allows taking only the given modules into account (e.g. when a module is powered down, but part of the data).

  `**params` can be any of the regular parameter conditions, and prevents it from being inferred from data. The object attempts to be as greedy as possible and determine it from any applicable source, e.g. acquisition rate can be taken from the AGIPD FPGA comp device or the difference of pulse IDs in the data stream. If the sources in `data` are insufficient to construct the condition, an exception is thrown. This can be prevented by passing the missing parameters manually.

  For diagnostics, the actual extraction of any given parameter from data is implemented in its own static method, but that is an optional pattern.

- The `CalibrationData` class itself gains a `.from_data()` class method taking an `extra_data.DataCollection` and **optionally** a detector name. From that, it attempts to infer the detector name if missing via EXtra-data components, its detector type via CalCat and this pick the corresponding `ConditionsBase` type. Also, it infers `begin_at` from the data and thus attempt to initialize a proper .`CalibrationData` object via `.from_condition`. Any additional keyword arguments are passed to the conditions object, e.g. to overwrite parameters or sources.

For now, I implemented the necessary code to infer the condition for AGIPD, LPD and Jungfrau based on what we use in `pycalibration`, including (most) of its idiosyncracies. For AGIPD, I isolated the exact `pycalibration` code and ran it against this new API for a sample run of every proposal an AGIPD correction ever ran on with full agreement on all of them.

You can find a minimal example showcasing several situations [here](https://max-jhub.desy.de/user-redirect/notebooks/GPFS/exfel/data/scratch/schmidtp/caldata-examples.ipynb).
