### PR TITLE
Build wheels for newer Python versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.19.2
         env:
-          CIBW_BUILD: cp310-*
+          CIBW_BUILD: cp31[0123]-*
           CIBW_SKIP: "*-musllinux_*  pp*"
 
       - name: Upload artifacts


### PR DESCRIPTION
I just noticed that we only have Python 3.10 wheels on PyPI, so installing EXtra is slower on other versions, because it has to build the Cython code. This should make wheels for Python 3.10 - 3.13.