### PR TITLE
Add method to group xarray by scan steps

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -25,6 +25,8 @@ Added:
   supports `DataCollection` objects to reference a point in time
 - Pre-built packages will be available on PyPI for Python 3.10 - 3.13 from the
   next release, rather than only Python 3.10 (!377).
+- [Scan.group_xarray] method to make an xarray GroupBy object based on scan
+  steps (!379).
 
 Changed:
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -25,8 +25,8 @@ Added:
   supports `DataCollection` objects to reference a point in time
 - Pre-built packages will be available on PyPI for Python 3.10 - 3.13 from the
   next release, rather than only Python 3.10 (!377).
-- [Scan.group_xarray] method to make an xarray GroupBy object based on scan
-  steps (!379).
+- [Scan.group_data] method to make an xarray or pandas GroupBy object based on
+  scan steps (!379).
 
 Changed:
 

--- a/tests/test_components_scan.py
+++ b/tests/test_components_scan.py
@@ -2,6 +2,7 @@ from extra.components import Scan
 
 import pytest
 import numpy as np
+import pandas as pd
 import xarray as xr
 
 import extra_data
@@ -124,3 +125,19 @@ def test_scan_bin_multidimensional(mock_spb_aux_run):
 
     # Smoke test
     s.plot_bin_by_steps(xgm_intensity)
+
+
+def test_scan_group_xarray(mock_spb_aux_run):
+    s = Scan(mock_spb_aux_run["MOTOR/MCMOTORYFACE"])
+
+    pulse_midx = pd.MultiIndex.from_product([
+        mock_spb_aux_run.train_ids[:-5], range(10)
+    ], names=['trainId', 'pulseIndex'])
+    data = xr.DataArray(
+        np.zeros((len(pulse_midx), 5)),
+        dims=('pulse', 'sample'),
+        coords={'pulse': pulse_midx}
+    )
+
+    gb = s.group_xarray(data)
+    assert len(gb) == len(s.positions)

--- a/tests/test_components_scan.py
+++ b/tests/test_components_scan.py
@@ -127,17 +127,23 @@ def test_scan_bin_multidimensional(mock_spb_aux_run):
     s.plot_bin_by_steps(xgm_intensity)
 
 
-def test_scan_group_xarray(mock_spb_aux_run):
+def test_scan_group_data(mock_spb_aux_run):
     s = Scan(mock_spb_aux_run["MOTOR/MCMOTORYFACE"])
 
     pulse_midx = pd.MultiIndex.from_product([
         mock_spb_aux_run.train_ids[:-5], range(10)
     ], names=['trainId', 'pulseIndex'])
-    data = xr.DataArray(
+
+    # With xarray
+    data_xr = xr.DataArray(
         np.zeros((len(pulse_midx), 5)),
         dims=('pulse', 'sample'),
         coords={'pulse': pulse_midx}
     )
-
-    gb = s.group_xarray(data)
+    gb = s.group_data(data_xr)
     assert len(gb) == len(s.positions)
+
+    # With pandas
+    data_pd = pd.Series(np.zeros(len(pulse_midx)), index=pulse_midx)
+    gb2 = s.group_data(data_pd)
+    assert len(gb2) == len(s.positions)


### PR DESCRIPTION
This is similar to `Scan.split_by_steps`, but:

1. It produces an xarray GroupBy object, rather than just a sequence of smaller DataArrays. This has shortcuts for e.g. getting the mean of each group as a new xarray.
2. It works if the trainId coordinate is one level in a MultiIndex. I don't much like the way I've done this, but I haven't found a neater way - ideas welcome.

This is based on a function I wrote in fxeutils, but generalised a bit.