### PR TITLE
Markdown repr for calibration conditions objects

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -32,6 +32,8 @@ Changed:
   instead of zeros as a fill value for runs with a varying number of pulses
   (!347).
 - [imshow2()][extra.utils.imshow2] will now add a colorbar automatically (!351).
+- [Calibration](calibration.md) conditions objects can now be displayed as
+  Markdown in Jupyter notebooks (!381).
 
 ## [2025.1]
 

--- a/src/extra/calibration.py
+++ b/src/extra/calibration.py
@@ -1,7 +1,7 @@
 import json
 import re
 from collections.abc import Mapping
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field, fields, replace
 from datetime import date, datetime, time, timezone
 from enum import IntFlag
 from functools import lru_cache
@@ -957,6 +957,14 @@ class CalibrationData(Mapping):
 
 class ConditionsBase:
     calibration_types = {}  # For subclasses: {calibration: [parameter names]}
+
+    def _repr_markdown_(self):
+        attr_names = [f.name for f in fields(self)]
+        items = []
+        for n in attr_names:
+            if (value := getattr(self, n)) is not None:
+                items.append(f"- {n.replace('_', ' ').capitalize()}: {value}")
+        return '\n'.join(items)
 
     def make_dict(self, parameters) -> dict:
         d = dict()

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -5,6 +5,7 @@ import re
 import numpy as np
 import pytest
 import xarray as xr
+from IPython.core.formatters import MarkdownFormatter
 
 from extra.calibration import (
     CalCatAPIClient,
@@ -245,3 +246,9 @@ def test_format_time(mock_spb_aux_run):
 
     assert by_run.tzinfo is not None
     assert (by_run - datetime.now(tz=by_run.tzinfo)) < timedelta(minutes=10)
+
+
+def test_conditions_markdown():
+    cond = LPDConditions()
+    md = MarkdownFormatter()(cond)  # Smoketest
+    assert isinstance(md, str)


### PR DESCRIPTION
Simply showing all non-None parameters:

<img width="318" height="248" alt="image" src="https://github.com/user-attachments/assets/88e1a40f-e6cd-4dcb-a418-cf902a29c6b8" />

The capitalisation isn't always exactly the same as in CalCat, e.g. 'Pixels x' instead of 'Pixels X', because getting that right is more complex, and I don't think it actually matters.