### PR TITLE
Add pulse selection machinery and manual pulse patterns

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -28,6 +28,12 @@ Added:
   find the constants suitable for a given `DataCollection`
 - [DetectorData][extra.calibration.DetectorData] to obtain detector metadata and
   module mapping from the Calibration Cataloge (!408).
+- [PulsePattern.select_pulses][extra.components.pulses.PulsePattern.select_pulses],
+  [PulsePattern.deselect_pulses][extra.components.pulses.PulsePattern.deselect_pulses] and
+  [PulsePattern.union][extra.components.pulses.PulsePattern.union] to modify pulse patterns (!417).
+- [ManualPulses][extra.components.ManualPulses] to generate custom pulse pattern with
+  the same interface as existing
+  [PulsePattern][extra.components.pulses.PulsePattern]-based components (!417).
 - [SpectrometerCalibration][extra.gui.jupyter.SpectrometerCalibration] to
   provide a Jupyter widget for energy calibration of 2D X-ray spectrum data
   (!363).

--- a/docs/components/pulse-patterns.md
+++ b/docs/components/pulse-patterns.md
@@ -6,4 +6,6 @@
 
 ::: extra.components.MachinePulses
 
+::: extra.components.ManualPulses
+
 ::: extra.components.DldPulses

--- a/docs/components/pulse-patterns.md
+++ b/docs/components/pulse-patterns.md
@@ -1,11 +1,95 @@
+
+Analog to European XFEL's timing structure, its data is also organized in trains
+identifed by a unique and global train ID. Some data however, in particular many
+of the primary detectors in an experiment like AGIPD, DSSC, LPD or fast digitizers,
+also resolves every or at least some of the underlying pulses a train is composed of.
+
+![European XFEL timing structure](../images/trains_pulses.png){ width="75%" align=center }
+
+The `PulsePattern` family of components allows access to pulse patterns recorded
+by various sources. For example, in order to obtain the FEL pulses for a particular
+SASE:
+
+```python
+p = XrayPulses(run)
+p.pulse_ids()
+```
+
+There are different types available depending on the source that should be used for
+the pulse pattern information, but they all offer the same interface as
+[`PulsePattern`][extra.components.pulses.PulsePattern] for access. Furthermore,
+many other components like [`AdqRawChannel`][extra.components.AdqRawChannel] can be
+given a [`PulsePattern`][extra.components.pulses.PulsePattern] component to customize
+how pulse-resolved data is interpreted.
+
+The primary source of pulse pattern information is the bunch pattern table from
+the machine side, which is recorded either through a so called timeserver or a
+pulse pattern decoder source. There are three different components available to access
+different parts of this data:
+
+- [`XrayPulses`][extra.components.XrayPulses] for FEL pulses.
+- [`OpticalLaserPulses`][extra.components.OpticalLaserPulses] for optical laser
+  or PPL pulses.
+- [`MachinePulses`][extra.components.MachinePulses] for machine-related pulses
+  or any other data in the bunch pattern table.
+
+There is a special component available for pump-probe experiments, which can combine
+FEL and PPL pulses into a single pattern with corresponding labels which of these two
+is present in a given pulse:
+
+- [`PumpProbePulses`][extra.components.PumpProbePulses] for combined FEL/PPL
+  pulse patterns.
+
+All of the components above offer the interface of
+[`TimeserverPulses`][extra.components.pulses.TimeserverPulses] in addition to the
+general interface of [`PulsePattern`][extra.components.pulses.PulsePattern].
+
+Apart from that, there are components to access other sources of pulse pattern
+information via the same [`PulsePattern`][extra.components.pulses.PulsePattern]
+interface:
+
+- [`ManualPulses`][extra.components.ManualPulses] for manually created pulse
+  pattern or modifications of existing patterns via
+  [`select_pulses()`][extra.components.pulses.PulsePattern.select_pulses], 
+  [`deselect_pulses()`][extra.components.pulses.PulsePattern.select_pulses] or
+  [`union()`][extra.components.pulses.PulsePattern.union].
+
+- [`DldPulses`][extra.components.DldPulses] for pulse informations generated as
+  part of processed DLD (delay line detector) data.
+
+As opposed to trains, there is no single global mechanism how to record pulses and
+some sources use their own identification scheme. Therefore, these components aim to
+refer to the location of pulses in the machine bunch pattern table wherever possible
+as a shared and universal identification called *pulse ID*. An enumeration of pulses
+for a single SASE, instrument or device is called *pulse index*. If desired, the
+*pulse time* uses the relative time to the beginning of a subtrain.
+
+::: extra.components.pulses.PulsePattern
+
+::: extra.components.pulses.TimeserverPulses
+	options:
+		inherited_members: no
+
 ::: extra.components.XrayPulses
+	options:
+		inherited_members: no
 
 ::: extra.components.OpticalLaserPulses
+	options:
+		inherited_members: no
 
 ::: extra.components.PumpProbePulses
+	options:
+		inherited_members: no
 
 ::: extra.components.MachinePulses
+	options:
+		inherited_members: no
 
 ::: extra.components.ManualPulses
+    options:
+		inherited_members: false
 
 ::: extra.components.DldPulses
+    options:
+		inherited_members: false

--- a/src/extra/components/__init__.py
+++ b/src/extra/components/__init__.py
@@ -1,7 +1,7 @@
 
 from .scantool import Scantool  # noqa
 from .pulses import XrayPulses, OpticalLaserPulses, MachinePulses, \
-    PumpProbePulses, DldPulses  # noqa
+    PumpProbePulses, ManualPulses, DldPulses  # noqa
 from .scan import Scan  # noqa
 from .xgm import XGM  # noqa
 from .dld import DelayLineDetector  # noqa

--- a/src/extra/components/pulses.py
+++ b/src/extra/components/pulses.py
@@ -129,16 +129,21 @@ class PulsePattern:
     """Abstract interface to pulse patterns.
 
     This class should not be instantiated directly, but one of its
-    implementationsd `XrayPulses` or `OpticalLaserPulses`. It provides
-    the shared interface to access any pulse pattern.
-
-    Instances of this class are assumed to be immutable, which is
-    exploited in various methods for caching purposes. An implementation
-    should not allow altering its internal object state in a way that
-    causes return values of public APIs to change.
-
-    Requires to implement _get_pulse_ids().
+    implementations such as `XrayPulses` or `OpticalLaserPulses`. It
+    provides the shared interface accessible from all oher pulse pattern
+    implementations, however.
     """
+
+    # Instances of this class are assumed to be immutable, which is
+    # exploited in various methods for caching purposes. An implementation
+    # should not allow altering its internal object state in a way that
+    # causes return values of public APIs to change.
+
+    # The minimum requirement for a custom pulse pattern type is to
+    # implement the abstract method `_get_pulse_ids()`.
+    # If the underlying pattern may also describe pulse-less trains,
+    # `_get_train_ids()` should be overwritten as well. Its default
+    # implementation will return only the train IDs with pulses.
 
     # Number of elements in bunch pattern table according to XFEL Timing
     # System Specification, Version 2.2 (2013). The original table may
@@ -964,12 +969,14 @@ class TimeserverPulses(PulsePattern):
     """Abstract interface to timeserver-based based pulse patterns.
 
     This class should not be instantiated directly, but one of its
-    implementations `XrayPulses` or `OpticalLaserPulses`. It provides
-    the shared interface to access pulse patterns encoded in the bunch
-    pattern table.
-
-    Requires _mask_table() and _get_ppdecoder_nodes() to be implemented.
+    implementations such as [`XrayPulses`][extra.components.XrayPulses]
+    or [`OpticalLaserPulses`][extra.components.OpticalLaserPulses]. It
+    provides the shared interface to access pulse patterns encoded in
+    the timeserver or pulse pattern decoder data.
     """
+
+    # An implementation os required to implement _mask_table() and
+    # _get_ppdecoder_nodes().
 
     # Timeserver class ID and regular expressions.
     _timeserver_class = 'TimeServer'
@@ -1234,7 +1241,7 @@ class TimeserverPulses(PulsePattern):
         return self.machine_pulses().pulse_repetition_rates().min()
 
     @lru_cache
-    def is_sa1_interleaved_with_sa3(self) -> Optional[bool]:
+    def is_sa1_interleaved_with_sa3(self) -> bool | None:
         """Check whether SASE1 and SASE3 pulses are interleaved.
 
         Due to their unique geometry, the pulses of the SASE1 and SASE3
@@ -1250,8 +1257,9 @@ class TimeserverPulses(PulsePattern):
         returned.
 
         Returns:
-            (bool or None) Whether SA1 and SA3 are interleaved or None
-                if the pulse patterns do not allow the determination.
+            is_interleaved (bool or None): Whether SA1 and SA3 are
+                interleaved or None if the pulse patterns do not allow
+                the determination.
         """
 
         return self._get_xray_pulses(1).is_interleaved_with(

--- a/src/extra/components/pulses.py
+++ b/src/extra/components/pulses.py
@@ -10,6 +10,7 @@ from warnings import warn
 import re
 
 import numpy as np
+import pandas as pd
 
 from euxfel_bunch_pattern import is_sase, is_laser, \
     PPL_BITS, DESTINATION_TLD, DESTINATION_T4D, DESTINATION_T5D, \
@@ -225,7 +226,6 @@ class PulsePattern:
             # thus are equal if length matches.
             return act_entries
 
-        import pandas as pd
         ext_entries = pd.Series(
             np.zeros_like(train_ids, dtype=act_entries.dtype),
             index=pd.Index(train_ids, name='trainId'))
@@ -573,7 +573,6 @@ class PulsePattern:
             # Drop train ID dimensions.
             pulse_ids = _drop_first_level(pulse_ids)
         else:
-            import pandas as pd
             pulse_ids = pd.Series([], dtype=np.int32)
 
         return (pulse_ids if labelled else pulse_ids.to_numpy()).copy()
@@ -879,7 +878,6 @@ class PulsePattern:
         if pulse_dtype is not None:
             index_levels[pulse_dim] = index_levels[pulse_dim].astype(pulse_dtype)
 
-        import pandas as pd
         return pd.MultiIndex.from_arrays(
             list(index_levels.values()), names=list(index_levels.keys()))
 
@@ -927,7 +925,6 @@ class PulsePattern:
         pulse_ids = self.pulse_ids(copy=False)
 
         if labelled:
-            import pandas as pd
             def gen_pulse_ids(train_idx):
                 try:
                     return pulse_ids.loc[tids[train_idx]].copy()
@@ -1138,8 +1135,6 @@ class TimeserverPulses(PulsePattern):
                     for node in nodes], []))]
 
         counts = [len(pids) for pids in pids_by_train]
-
-        import pandas as pd
 
         if not counts:
             # Immediately return an empty series if there is no data.
@@ -1896,7 +1891,6 @@ class PumpProbePulses(XrayPulses, OpticalLaserPulses):
             fel_by_train.append(np.isin(pids, fel_pids))
             ppl_by_train.append(np.isin(pids, ppl_pids))
 
-        import pandas as pd
         index = pd.MultiIndex.from_arrays([
             np.repeat(train_ids, counts),
             np.concatenate([np.arange(count) for count in counts]),
@@ -2030,7 +2024,6 @@ class ManualPulses(PulsePattern):
         if isinstance(train_ids, TrainData):
             train_ids = train_ids.train_ids
 
-        import pandas as pd
         pulse_ids_ser = pd.Series(
             np.tile(pulse_ids, len(train_ids)), dtype=np.int32,
             index=pd.MultiIndex.from_product([
@@ -2157,7 +2150,6 @@ class DldPulses(PulsePattern):
             index_levels['fel'] = triggers['fel'].copy()
             index_levels['ppl'] = triggers['ppl'].copy()
 
-        import pandas as pd
         index = pd.MultiIndex.from_arrays(
             list(index_levels.values()), names=list(index_levels.keys()))
 
@@ -2187,7 +2179,6 @@ class DldPulses(PulsePattern):
         triggers = drop_fields(self._key.ndarray(), ['pulse', 'fel', 'ppl'])
 
         if labelled:
-            import pandas as pd
             return pd.DataFrame(data=triggers, index=self.build_pulse_index())
         else:
             return triggers

--- a/src/extra/components/pulses.py
+++ b/src/extra/components/pulses.py
@@ -14,18 +14,114 @@ import numpy as np
 from euxfel_bunch_pattern import is_sase, is_laser, \
     PPL_BITS, DESTINATION_TLD, DESTINATION_T4D, DESTINATION_T5D, \
     PHOTON_LINE_DEFLECTION
-from extra_data import SourceData, KeyData, by_id
+from extra_data import DataCollection, SourceData, KeyData, by_index, by_id
 
 from .utils import identify_sase, _instrument_to_sase
 
 
 __all__ = ['XrayPulses', 'OpticalLaserPulses', 'MachinePulses',
-           'PumpProbePulses', 'DldPulses']
+           'PumpProbePulses', 'ManualPulses', 'DldPulses']
+
+TrainData = DataCollection | SourceData | KeyData
 
 
 def _drop_first_level(pd_val):
     """Return first group and drop first level of a pandas multi index."""
     return pd_val.loc[pd_val.head(1).index.values[0][0]]
+
+
+def _reset_pulse_index(pulse_ids):
+    """Re-enumerate pulse index index level."""
+
+    pulse_ids.index = pulse_ids.index.set_codes(
+        np.concatenate([np.arange(num) for num
+                        in pulse_ids.groupby('trainId').count()]),
+        level='pulseIndex')
+
+    return pulse_ids
+
+
+def _is_positive_slice(s):
+    """Check whether a slice only uses positive attributes."""
+    return (
+        (s.start is None or s.start >= 0) and
+        (s.stop is None or s.stop >= 0) and
+        (s.step is None or s.step >= 0)
+    )
+
+
+def _select_pulse_ids(pulse_ids, pulse_sel, train_sel):
+    """Select pulses by train."""
+
+    if train_sel is not None:
+        from extra_data.read_machinery import select_train_ids
+        train_sel = select_train_ids(
+            # Select on actual train IDs with pulses.
+            list(pulse_ids.index.to_frame()['trainId'].unique()),
+            train_sel)
+
+    else:
+        train_sel = np.s_[:]
+
+    if isinstance(pulse_sel, by_index):
+        # Convert by_index to a regular slice.
+        pulse_sel = pulse_sel.value
+
+    if isinstance(pulse_sel, by_id):
+        # Could be a slice or a list/ndarray
+        if isinstance(pulse_sel.value, slice):
+            start = pulse_sel.value.start or 0
+            stop = pulse_sel.value.stop or 9999
+            step = pulse_sel.value.step or 1
+
+            def slice_pulses(pulse_ids):
+                return pulse_ids[(pulse_ids > start) &
+                                    (pulse_ids < stop) &
+                                    (pulse_ids % step == start % step)]
+
+        elif isinstance(pulse_sel.value, (list, np.ndarray)):
+            new_pulse_ids = pulse_sel.value
+
+            def slice_pulses(pulse_ids):
+                return pulse_ids[pulse_ids.isin(new_pulse_ids)]
+
+        else:
+            raise TypeError(type(pulse_sel.value))
+
+    elif isinstance(pulse_sel, np.ndarray) and pulse_sel.dtype == np.bool_:
+        def slice_pulses(pulse_ids):
+            if len(pulse_sel) < len(pulse_ids):
+                raise ValueError(
+                    f'pulse selection too short for number of pulses '
+                    f'({len(pulse_ids)}) in train {pulse_ids.name}')
+
+            return pulse_ids[pulse_sel[:len(pulse_ids)]]
+
+    elif isinstance(pulse_sel, slice):
+        if _is_positive_slice(pulse_sel):
+            # Fast-path for non-negative slice values.
+
+            if pulse_sel.stop is not None:
+                # Pandas label-based indexing is inclusive of the slice
+                # upper boundary, which is unintuitive for
+                # location-based indexing. Since the labels are an index
+                # here, modify the slice accordingly.
+                pulse_sel = slice(
+                    pulse_sel.start, pulse_sel.stop - 1, pulse_sel.step)
+
+            return pulse_ids.loc[train_sel, pulse_sel]
+
+        def slice_pulses(pulse_ids):
+            return pulse_ids.iloc[pulse_sel]
+
+    elif isinstance(pulse_sel, (list, np.ndarray)):
+        return pulse_ids.loc[train_sel, pulse_sel]
+
+    else:
+        raise TypeError(type(pulse_sel))
+
+    return pulse_ids.loc[train_sel].groupby(
+        'trainId', group_keys=False).apply(slice_pulses)
 
 
 class PulsePattern:
@@ -258,6 +354,163 @@ class PulsePattern:
             res._pulse_ids = None
 
         return res
+
+    def select_pulses(self, pulse_sel, train_sel=None,
+                      reset_index=True) -> ManualPulses:
+        """Select a subset of pulses.
+
+        The possible options for pulse selection are:
+
+        - By pulse index using `extra_data.by_index` with a slice, list or ndarray:
+            ```
+            by_index[5:]  # All pulses after the first five.
+            by_index[[0, 1, 2]]  # Explicitly the first three pulses.
+            ```
+            Slices with negative indices are supported, but may be
+            significantly slower than non-negative indices. `by_index`
+            may be omitted and a regular slice, list or ndarray used
+            directly instead.
+
+        - By pulse ID using `extra_data.by_id` with a slice, list or ndarray:
+            ```
+            by_id[:1500]  # All pulse IDs up to 1500.
+            by_id[[1146, 1154]]  # Explicitly pulse IDs 1146 and 1154.
+            ```
+
+        - By a boolean ndarray acting as a mask, must contain at least as
+          many elements as the highest number of pulses per train,
+            ```
+            # Selects every other pulse.
+            np.array([True, False, True, False, True])
+            ```
+
+        The train selection may be any object accepted by
+        [DataCollection.select_trains()][extra_data.DataCollection.select_trains].
+        If specified, the pulse selection is only applied for the
+        selected trains. This will not change the trains described by
+        the resulting pulse pattern, but only which trains actually
+        contain any pulses.
+
+        Args:
+            pulse_sel (by_index or by_id or slice or list or numpy.ndarray):
+                Pulse selection, may be a slice by pulse index or pulse
+                ID or boolean mask.
+            train_sel (by_index or by_id or slice or list or numpy.ndarray, optional):
+                Train selection to which the pulse selection is applied.
+            reset_index (bool, optional): Whether to re-enumerate the
+                pulseIndex index level, True by default.
+
+        Returns:
+            pulses (ManualPulses): New manual pulse patterns containing
+                only the selected pulses.
+        """
+
+        pulse_ids = _select_pulse_ids(self.pulse_ids(copy=False),
+                                      pulse_sel, train_sel)
+
+        if reset_index:
+            pulse_ids = _reset_pulse_index(pulse_ids)
+
+        return ManualPulses(self._get_train_ids(), pulse_ids)
+
+    def deselect_pulses(self, pulse_sel, train_sel=None,
+                        reset_index=True) -> ManualPulses:
+        """Deselect a subset of pulses.
+
+        This method accepts the same option as
+        [PulsePattern.select_pulses()][extra.components.pulses.PulsePattern.select_pulses]
+        for its arguments, but removes the selected pulses and removes
+        a pattern that remains.
+
+        Args:
+            pulse_sel (by_index or by_id or slice or list or numpy.ndarray):
+                Pulse selection, may be a slice by pulse index or pulse
+                ID or boolean mask.
+            train_sel (by_index or by_id or slice or list or numpy.ndarray, optional):
+                Train selection to which the pulse selection is applied.
+            reset_index (bool, optional): Whether to re-enumerate the
+                pulseIndex index level, True by default.
+
+        Returns:
+            pulses (ManualPulses): New manual pulse patterns not
+                containing the deselected pulses.
+        """
+
+        orig_pulse_ids = self.pulse_ids(copy=False)
+        sel_pulse_ids = _select_pulse_ids(orig_pulse_ids, pulse_sel, train_sel)
+
+        mask = pd.Series(np.ones_like(orig_pulse_ids, dtype=bool),
+                         index=orig_pulse_ids.index)
+        mask[sel_pulse_ids.index] = False
+
+        new_pulse_ids = orig_pulse_ids[mask]
+
+        if reset_index:
+            new_pulse_ids = _reset_pulse_index(new_pulse_ids)
+
+        return ManualPulses(self._get_train_ids(), new_pulse_ids)
+
+    def union(self, *others) -> ManualPulses:
+        """Join the pulses in this pattern with one or more others.
+
+        Any additional pulse index columns, e.g. flags for FEL/PPL
+        pulses as used by [`PumpProbePulses`][extra.components.PumpProbePulses]
+        are currently removed.
+
+        Args:
+            *others (PulsePattern): Pulse patterns to join with.
+
+        Returns:
+            pulses (ManualPulses): New manual pulse pattern containing
+                the union of all pulses.
+        """
+
+        self_pulse_ids = self.pulse_ids(copy=False)
+        if len(self_pulse_ids.index.names) > 2:
+            self_pulse_ids.index = self_pulse_ids.index.droplevel(
+                level=self_pulse_ids.index.names[2:])
+
+        if not others:
+            return ManualPulses(self._get_train_ids(), self_pulse_ids)
+
+        new_train_ids = self._get_train_ids()
+        pulse_ids_series = [self_pulse_ids]
+
+        for other in others:
+            other_pulse_ids = other.pulse_ids(copy=False)
+            if len(other_pulse_ids.index.names) > 2:
+                other_pulse_ids.index = other_pulse_ids.index.droplevel(
+                    level=other_pulse_ids.index.names[2:])
+
+            pulse_ids_series.append(other_pulse_ids)
+            new_train_ids = np.union1d(new_train_ids, other._get_train_ids())
+
+        act_train_ids = []  # May be less than new_train_ids!
+        new_pulse_ids = []
+        pulse_counts = []
+
+        merged_pulse_ids = pd.concat(pulse_ids_series)
+        for train_id, train_pulses in merged_pulse_ids.groupby('trainId'):
+            new_train_pulses = np.unique(train_pulses.sort_values().to_numpy())
+
+            act_train_ids.append(train_id)
+            new_pulse_ids.append(new_train_pulses)
+            pulse_counts.append(len(new_train_pulses))
+
+        index = pd.MultiIndex.from_arrays(
+            [np.repeat(act_train_ids, pulse_counts),
+            np.concatenate([np.arange(num) for num in pulse_counts])],
+            names=['trainId', 'pulseIndex'])
+
+        new_pulse_ids = pd.Series(np.concatenate(new_pulse_ids), index=index)
+
+        return ManualPulses(new_train_ids, new_pulse_ids)
+
+    def __or__(self, other) -> ManualPulses:
+        return self.union(other)
+
+    def __ior__(self, other) -> ManualPulses:
+        return self.union(other)
 
     def pulse_ids(self, labelled=True, copy=True):
         """Get pulse IDs.
@@ -1729,6 +1982,97 @@ class PumpProbePulses(XrayPulses, OpticalLaserPulses):
             return (bitfield & 2).astype(bool)
         else:
             raise ValueError(f"{field=!r} parameter was not 'fel'/'ppl'/None")
+
+
+class ManualPulses(PulsePattern):
+    """Manual pulse patterns.
+
+    The pattern described by this component is directly loaded from data,
+    but either generated manually or modified from another
+    [`PulsePattern`][extra.components.pulses.PulsePattern]-based
+    component through
+    [`select_pulses()`][extra.components.pulses.PulsePattern.select_pulses],
+    [`deselect_pulses()`][extra.components.pulses.PulsePattern.select_pulses]
+    or [`union()`][extra.components.pulses.PulsePattern.union].
+    """
+
+    def __init__(self, train_ids, pulse_ids):
+        super().__init__()
+
+        self._train_ids = train_ids
+        self._pulse_ids = pulse_ids
+
+    def _get_train_ids(self):
+        return self._train_ids
+
+    def _get_pulse_ids(self):
+        return self._pulse_ids
+
+    def __repr__(self):
+        return "<{} for {} pulses in {} trains>".format(
+            type(self).__name__, len(self._pulse_ids), len(self._train_ids))
+
+    @classmethod
+    def from_constant_pulses(cls, train_ids, pulse_ids):
+        """Generate a pulse pattern from constant pulse IDs.
+
+        Args:
+            train_ids (numpy.typing.ArrayLike or extra_data.DataCollection or extra_data.SourceData or extra_data.KeyData):
+                Train IDs or data to take train IDs from.
+            pulse_ids (numpy.typing.ArrayLike): Pulse IDs of a single
+                train to be repeated in every train.
+
+        Returns:
+            pulses (ManualPulses): Manual pulse pattern with specified
+                pulse IDs in every train.
+        """
+
+        if isinstance(train_ids, TrainData):
+            train_ids = train_ids.train_ids
+
+        import pandas as pd
+        pulse_ids_ser = pd.Series(
+            np.tile(pulse_ids, len(train_ids)), dtype=np.int32,
+            index=pd.MultiIndex.from_product([
+                train_ids, np.arange(len(pulse_ids))],
+                names=['trainId', 'pulseIndex']))
+
+        return cls(train_ids, pulse_ids_ser)
+
+    @classmethod
+    def from_constant_pattern(cls, train_ids, pulses_per_train,
+                              repetition_rate=None, pulse_period=None,
+                              pulse_id_offset=0):
+        """Generate a uniform pulse pattern.
+
+        Requires either `repetition_rate` or `pulse_period` to be passed.
+
+        Args:
+            train_ids (numpy.typing.ArrayLike or extra_data.DataCollection or extra_data.SourceData or extra_data.KeyData):
+                Train IDs or data to take train IDs from.
+            pulses_per_train (int): Number of pulses per train.
+            repetition_rate (float, optional): Repetition rate in Hz,
+                mutually exclusive with pulse_period.
+            pulse_period (int, optional): Period between pulses in units
+                of 4.5 MHz, mutually exclusive with repetition_rate.
+            pulse_id_offset (int, optional): Pulse ID for the first
+                generated pulse in each train, 0 by default.
+
+        Returns:
+            pulses (ManualPulses): Manual pulse pattern with uniform
+                pulses in every train.
+        """
+
+        if repetition_rate is not None:
+            pulse_period = int(round(1.3e9 / 288 / repetition_rate , 0))
+        elif pulse_period is None:
+            raise ValueError('must specify either repetition_rate or '
+                             'pulse_period')
+
+        pulse_ids = np.arange(pulses_per_train) * pulse_period \
+            + pulse_id_offset
+
+        return cls.from_constant_pulses(train_ids, pulse_ids)
 
 
 class DldPulses(PulsePattern):

--- a/tests/test_components_pulses.py
+++ b/tests/test_components_pulses.py
@@ -9,9 +9,9 @@ import extra
 
 from euxfel_bunch_pattern import PPL_BITS, DESTINATION_TLD, DESTINATION_T5D, \
     PHOTON_LINE_DEFLECTION
-from extra.data import RunDirectory, SourceData, KeyData, by_id
+from extra.data import RunDirectory, SourceData, KeyData, by_index, by_id
 from extra.components import XrayPulses, OpticalLaserPulses, MachinePulses, \
-    PumpProbePulses, DldPulses
+    PumpProbePulses, ManualPulses, DldPulses
 
 from .mockdata import assert_equal_sourcedata, assert_equal_keydata
 
@@ -761,3 +761,171 @@ def test_pump_probe_specials(mock_spb_aux_run, mock_sqs_remi_run):
             names=('trainId', 'pulseIndex', 'fel', 'ppl')))
 
     assert not pulses.is_constant_pattern()
+
+
+def test_manual_pulses():
+    tids = [100, 101, 102, 104]
+    pids = [1, 2, 3, 1, 2, 3, 1, 2, 4, 5]
+    index = pd.MultiIndex.from_arrays(
+        # 2nd-to-last train has four pulses, last train has no pulses.
+        [tids[:-1] * 3 + [tids[-2]], [0, 1, 2] * 3 + [3]],
+        names=['trainId', 'pulseIndex'])
+    p = ManualPulses(tids, pd.Series(pids, dtype=np.int32, index=index))
+    np.testing.assert_array_equal(p.pulse_counts(), [3, 3, 4, 0])
+    np.testing.assert_array_equal(p.pulse_ids(), pids)
+    assert p.pulse_ids().index.names == ['trainId', 'pulseIndex']
+
+    p = ManualPulses.from_constant_pulses(
+        [100, 101, 102], [20, 22, 26, 28, 32, 34])
+    np.testing.assert_array_equal(p.pulse_ids(), [20, 22, 26, 28, 32, 34] * 3)
+    np.testing.assert_array_equal(p.pulse_counts(), 6)
+
+    with pytest.raises(ValueError):
+        # Missing repetition_rate / pulse_period.
+        ManualPulses.from_constant_pattern([100, 101, 102], 2)
+
+    p = ManualPulses.from_constant_pattern(
+        [100, 101, 102], 2, repetition_rate=1.1e6, pulse_id_offset=10)
+    np.testing.assert_array_equal(p.pulse_ids(), [10, 14, 10, 14, 10, 14])
+    np.testing.assert_array_equal(p.pulse_counts(), 2)
+
+
+def test_select_pulses(mock_spb_aux_run):
+    p = XrayPulses(mock_spb_aux_run.select('SPB*'))
+
+    # Basic index-based slices.
+    subp = p.select_pulses(np.s_[2:4])
+    assert isinstance(subp, ManualPulses)
+
+    pids = subp.pulse_ids()  # Also used below to compare with other modes.
+    assert len(pids) == 180
+    np.testing.assert_array_equal(pids.iloc[:80], [1012, 1018] * 40)
+    np.testing.assert_array_equal(pids.iloc[80:], [1024, 1036] * 50)
+
+    np.testing.assert_array_equal(
+        pids.index.get_level_values('pulseIndex'), [0, 1] * 90)
+
+    counts = subp.pulse_counts()
+    np.testing.assert_array_equal(counts.index, np.arange(10000, 10100))
+    np.testing.assert_array_equal(counts[:10], 0)
+    np.testing.assert_array_equal(counts[10:], 2)
+
+    # Construct index list identical to index slice above.
+    pd.testing.assert_series_equal(pids, p.select_pulses([2, 3]).pulse_ids())
+    pd.testing.assert_series_equal(
+        pids, p.select_pulses(np.array([2, 3])).pulse_ids())
+
+    # Explicit use of by_index
+    pd.testing.assert_series_equal(
+        pids, p.select_pulses(by_index[2:4]).pulse_ids())
+    pd.testing.assert_series_equal(
+        pids, p.select_pulses(by_index[[2, 3]]).pulse_ids())
+    pd.testing.assert_series_equal(
+        pids, p.select_pulses(by_index[np.array([2, 3])]).pulse_ids())
+
+    # Construct mask identical to index-based selection above.
+    mask = np.zeros(50, dtype=bool)
+    mask[2:4] = True
+    pd.testing.assert_series_equal(pids, p.select_pulses(mask).pulse_ids())
+
+    with pytest.raises(ValueError):
+        p.select_pulses(mask[:-1])  # Mask too short
+
+    # ID-based slices.
+    subp = p.select_pulses(by_id[1020:1040])
+    pids = subp.pulse_ids()
+    np.testing.assert_array_equal(pids.iloc[:120], [1024, 1030, 1036] * 40)
+    np.testing.assert_array_equal(pids.iloc[120:], [1024, 1036] * 50)
+
+    counts = subp.pulse_counts()
+    np.testing.assert_array_equal(counts.index, np.arange(10000, 10100))
+    np.testing.assert_array_equal(counts[:10], 0)
+    np.testing.assert_array_equal(counts[10:50], 3)
+    np.testing.assert_array_equal(counts[50:], 2)
+
+    # Construct ID list identical to ID slice above.
+    pd.testing.assert_series_equal(
+        pids, p.select_pulses(by_id[[1024, 1030, 1036]]).pulse_ids())
+    pd.testing.assert_series_equal(
+        pids, p.select_pulses(by_id[np.array([1024, 1030, 1036])]).pulse_ids())
+
+    # Index-based slices, but with steps.
+    pids = p.select_pulses(by_index[2:8:4]).pulse_ids()
+    assert len(pids) == 180
+    np.testing.assert_array_equal(pids.iloc[:80], [1012, 1036] * 40)
+    np.testing.assert_array_equal(pids.iloc[80:], [1024, 1072] * 50)
+
+    # Index-based slices, but negative.
+    pids = p.select_pulses(by_index[-6:-2]).pulse_ids()
+    assert len(pids) == 360
+    np.testing.assert_array_equal(
+        pids.iloc[:160], [1264, 1270, 1276, 1282] * 40)
+    np.testing.assert_array_equal(
+        pids.iloc[160:], [1228, 1240, 1252, 1264] * 50)
+
+    # ID-based slices, but with steps.
+    pids = p.select_pulses(by_id[1024:1040:6]).pulse_ids()
+    assert len(pids) == 130
+    np.testing.assert_array_equal(pids.iloc[:80], [1030, 1036] * 40)
+    np.testing.assert_array_equal(pids.iloc[80:], 1036)
+
+    # Without resetting index.
+    np.testing.assert_array_equal(
+        p.select_pulses(np.s_[2:4], reset_index=False).pulse_ids() \
+         .index.get_level_values('pulseIndex'),
+        [2, 3] * 90)
+
+    # Also using a train selector.
+    subp = p.select_pulses(by_id[[1024, 1030, 1036]],
+                           train_sel=by_id[10045:10055])
+
+    pids = subp.pulse_ids()
+    np.testing.assert_array_equal(pids.iloc[:15], [1024, 1030, 1036] * 5)
+    np.testing.assert_array_equal(pids.iloc[15:], [1024, 1036] * 5)
+
+    np.testing.assert_array_equal(
+        subp.pulse_counts().index, np.arange(10000, 10100))
+
+
+def test_deselect_pulses(mock_spb_aux_run):
+    p = XrayPulses(mock_spb_aux_run.select('SPB*'))
+
+    subp = p.deselect_pulses(by_id[1010:1250])
+    assert isinstance(subp, ManualPulses)
+
+    pids = subp.pulse_ids()
+    assert len(pids) == 650
+
+    np.testing.assert_array_equal(
+        pids.iloc[:400],
+        [1000, 1006, 1252, 1258, 1264, 1270, 1276, 1282, 1288, 1294] * 40)
+    np.testing.assert_array_equal(
+        pids.iloc[400:],
+        [1000, 1252, 1264, 1276, 1288] * 50)
+
+    np.testing.assert_array_equal(
+        pids.iloc[:400].index.get_level_values('pulseIndex'),
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] * 40)
+    np.testing.assert_array_equal(
+        pids.iloc[400:].index.get_level_values('pulseIndex'),
+        [0, 1, 2, 3, 4] * 50)
+
+    counts = subp.pulse_counts()
+    np.testing.assert_array_equal(counts.index, np.arange(10000, 10100))
+    np.testing.assert_array_equal(counts[:10], 0)
+    np.testing.assert_array_equal(counts[10:50], 10)
+    np.testing.assert_array_equal(counts[50:], 5)
+
+
+def test_union_pulses():
+    p1 = ManualPulses.from_constant_pulses(
+        [1000, 1001, 1002], [100, 102, 104])
+    p2 = ManualPulses.from_constant_pulses(
+        [1002, 1003, 1004], [100, 103, 105])
+    p = p1 | p2
+
+    assert isinstance(p, ManualPulses)
+    np.testing.assert_array_equal(p.pulse_counts(), [3, 3, 5, 3, 3])
+    np.testing.assert_array_equal(
+        p.pulse_ids(),
+        2 * [100, 102, 104] + [100, 102, 103, 104, 105] + 2 * [100, 103, 105])


### PR DESCRIPTION
The existing `PulsePattern`-based components can expose pulse patterns as described by data, but so far it was not possible to modify those patterns. Conceptually it seemed rather convoluted to track modifications from the data state. Independent of that, I meant to have some `ManualPulses` component for some time that exposes the same interface but allows to make up your own patterns. Turns out those two concepts actually are made for each other!

This PR adds said `ManualPulses` type that simply holds any desired pulse pattern internally without any data reference, and then implements `select_pulses()`, `deselect_pulses()` and `union()` on top of that - applying any such modification to a `PulsePattern` component will always return a `ManualPulses` object indicating it is no longer represents a pattern found in data. 

Furthermore, I tried to improve the documentation on these components with some introduction and examples.