### PR TITLE
Add dependabot config for Github actions & 7 day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,16 @@ updates:
     directory: "/.github/dependabot/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Following similar changes in EXtra-data