### PR TITLE
Improve regexp for timeserver sources to include new instances at SPB

### DIFF
--- a/src/extra/components/pulses.py
+++ b/src/extra/components/pulses.py
@@ -659,7 +659,7 @@ class TimeserverPulses(PulsePattern):
     # Timeserver class ID and regular expressions.
     _timeserver_class = 'TimeServer'
     _timeserver_control_re = re.compile(
-        r'^\w{3}_(BR|RR)_(UTC|SYS)\/TSYS\/TIMESERVER$')
+        r'^\w{3}_(BR|RR)_(UTC|SYS)\/TSYS\/(TIMESERVER|X2TIMER\d)$')
     _timeserver_pipeline_re = re.compile(r'^{}:outputBunchPattern'.format(
         _timeserver_control_re.pattern[:-1]))
 


### PR DESCRIPTION
I happened to stumble upon SPB runs that have as their only timeserver one that doesn't pass the regexp in `PulsePattern`. While this will mostly still work due to checks against device class, these can fail if control data is deselected. This PR extends the source regexp to include our new friend.