### PR TITLE
Fix/gui cache dir

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -50,6 +50,8 @@ Fixed:
 
 Changed:
 
+- [SpectrometerCalibration][extra.gui.jupyter.SpectrometerCalibration] no longer
+  saves loaded data to cache if `user_cache=False`.
 - `extra.recipes` package renamed to `extra.applications`
 - [XGM.pulse_energy()][extra.components.XGM.pulse_energy] will now insert NaNs
   instead of zeros as a fill value for runs with a varying number of pulses

--- a/src/extra/gui/jupyter/spectrometer_calibration.py
+++ b/src/extra/gui/jupyter/spectrometer_calibration.py
@@ -241,8 +241,7 @@ class SpectrometerCalibration:
             source (tuple[str, str]): data source
             image_data (np.ndarray): 2D array
             use_cache (bool): try loading data from cache if True (default).
-              Additionally, if it is set to False, loaded data will not be
-              cached.
+              If set to False, data will neither be loaded from nor written to cache.
         """
         self.image_data = image_data
         if image_data is None:

--- a/src/extra/gui/jupyter/spectrometer_calibration.py
+++ b/src/extra/gui/jupyter/spectrometer_calibration.py
@@ -362,7 +362,7 @@ class SpectrometerCalibration:
         mean_data = data.mean(dim="trainId")
 
         # cache data for faster loading unless use_cache=False
-        if not use_cache:
+        if use_cache:
             cache_path.mkdir(mode=666, exist_ok=True, parents=True)
             np.save(cache_path / fname, mean_data)
 

--- a/src/extra/gui/jupyter/spectrometer_calibration.py
+++ b/src/extra/gui/jupyter/spectrometer_calibration.py
@@ -240,7 +240,9 @@ class SpectrometerCalibration:
             run (int): run number
             source (tuple[str, str]): data source
             image_data (np.ndarray): 2D array
-            use_cache (bool): try loading data from cache if True (default)
+            use_cache (bool): try loading data from cache if True (default).
+              Additionally, if it is set to False, loaded data will not be
+              cached.
         """
         self.image_data = image_data
         if image_data is None:
@@ -359,9 +361,11 @@ class SpectrometerCalibration:
         data = kd.xarray().squeeze()
         mean_data = data.mean(dim="trainId")
 
-        # cache data for faster loading
-        cache_path.mkdir(mode=666, exist_ok=True, parents=True)
-        np.save(cache_path / fname, mean_data)
+        # cache data for faster loading unless use_cache=False
+        if not use_cache:
+            cache_path.mkdir(mode=666, exist_ok=True, parents=True)
+            np.save(cache_path / fname, mean_data)
+
         return mean_data
 
     # Widget Initialization Methods


### PR DESCRIPTION
Changed the scope of the `use_cache` option in the `SpectrometerCalibration` method so that it doesn't attempt to create a directory or save the averaged data into it. 

The reason behind this is that I was trying to open a run from XMPL where I have read but not write access (even to `${proposal}/scratch`). This problem could come up in other cases as well, not just with XMPL, if a DA person has access to a proposal but is not part of it.

There are other alternatives/possible additions to the proposed propsoed including:
1. Allow the user to pass-in a numpy array (like the `out=` option in `extra.data`) [@takluyver ]
2. Silently fall back to a writeable directory if user cannot write to `${proposal}/scratch`. For example, `${HOME}/.cache/extra` or something like that. 
3. Allow the user to pass-in a path where they do have write access. This has the advantage of giving the user control over where the cached files are saved so that they can delete them or pass the directory back to read from cache.

These options were discussed on Zulip with @turkot, @philsmt, and @takluyver.