### PR TITLE
Correct transmission calculation

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -47,6 +47,8 @@ Fixed:
   [DataArray][xarray.DataArray] inputs as well (!419).
 - Fix incorrect time units when using [OpticalLaserDelay][extra.components.OpticalLaserDelay]
   with pre-2022 BAM data (!425).
+- [CookieboxCalibration][extra.applications.CookieboxCalibration] takes polarization into account
+  when calculating transmission.
 
 Changed:
 

--- a/src/extra/applications/cookiebox.py
+++ b/src/extra/applications/cookiebox.py
@@ -319,8 +319,11 @@ class CookieboxCalibration(SerializableMixin):
       parallel: Whether to average the input data in parallel.
       beta: Beta parameter.
             For l=0 electrons, set to 2 for linear polarization, 0 to circular polarization.
-      tilt: Tilt angle for linear or elliptical polarization. Set to 0 for horizontal polarization,
-            or np.pi/2 for vertical linear polarization.
+      tilt: Tilt angle for linear or elliptical polarization.
+            It is assumed eTOF 0 makes an angle of 0 deg and therefore, the tilt
+            refers to that angle. Under such assumption, set to 0 for horizontal polarization,
+            or np.pi/2 for vertical linear polarization, if eTOF 0 is aligned
+            to the horizontal plane.
       P1: First Stokes parameter. Set to 1 for linear or circular polarization.
     """
     def __init__(self,

--- a/src/extra/applications/cookiebox.py
+++ b/src/extra/applications/cookiebox.py
@@ -870,7 +870,8 @@ class CookieboxCalibration(SerializableMixin):
 
         dsig_dth = 0.5*(1 + beta*(3*np.cos(theta)**2 - 1)/2)
         detected = self.tof_fit_result[tof_id].A
-        produced = self.calibration_mean_xgm[tof_id] * self.tof_fit_result[tof_id].Aa * dsig_dth
+        #produced = self.calibration_mean_xgm[tof_id] * self.tof_fit_result[tof_id].Aa * dsig_dth
+        produced = self.tof_fit_result[tof_id].Aa * dsig_dth
         en = detected[mask][eidx]/produced[mask][eidx]
         # interpolate normalization
         self.normalization[tof_id] = np.interp(self.energy_axis,
@@ -954,7 +955,7 @@ class CookieboxCalibration(SerializableMixin):
             a.plot(self.energy_axis, self.normalization[tof_id], c=c, lw=lw, ls=ls, label=f"eTOF {tof_id}")
         for a in ax:
             a.set(xlabel="Energy [eV]",
-                  ylabel=r"$\frac{\mathrm{detected}}{\mathrm{pulse energy} \times \mathrm{Auger-Meitner} \times \mathrm{polarization effect}}$ [1/$\mu$J]")
+                  ylabel=r"$\frac{\mathrm{detected}}{\mathrm{Auger-Meitner} \times \mathrm{polarization} \, \mathrm{effect}}$")
             a.legend(frameon=False, ncols=2)
 
     def plot_offsets(self):
@@ -1176,7 +1177,7 @@ class CookieboxCalibration(SerializableMixin):
 
             # interpolate
             #bad = np.isnan(pulses)
-            np.nan_to_num(pulses, copy=False)
+            pulses = np.nan_to_num(pulses, copy=True)
             o = np.apply_along_axis(lambda arr: np.interp(self.energy_axis, e[::-1], arr[::-1], left=0, right=0),
                                    axis=1,
                                    arr=pulses)

--- a/src/extra/applications/cookiebox.py
+++ b/src/extra/applications/cookiebox.py
@@ -317,7 +317,8 @@ class CookieboxCalibration(SerializableMixin):
                  Use `None` to guess it.
       stop_roi: End of the RoI, relative to the `first_pulse_offset`. Use `None` to guess it.
       parallel: Whether to average the input data in parallel.
-      beta: Polarization beta parameter. Set to 2 for linear polarization. Set to 0 to circular polarization.
+      beta: Beta parameter.
+            For l=0 electrons, set to 2 for linear polarization, 0 to circular polarization.
       tilt: Tilt angle for linear or elliptical polarization. Set to 0 for horizontal polarization,
             or np.pi/2 for vertical linear polarization.
       P1: First Stokes parameter. Set to 1 for linear or circular polarization.

--- a/src/extra/applications/cookiebox.py
+++ b/src/extra/applications/cookiebox.py
@@ -954,7 +954,7 @@ class CookieboxCalibration(SerializableMixin):
             a.plot(self.energy_axis, self.normalization[tof_id], c=c, lw=lw, ls=ls, label=f"eTOF {tof_id}")
         for a in ax:
             a.set(xlabel="Energy [eV]",
-                  ylabel="Transmission [a.u.]")
+                  ylabel=r"$\frac{\mathrm{detected}}{\mathrm{pulse energy} \times \mathrm{Auger-Meitner} \times \mathrm{polarization effect}}$ [1/$\mu$J]")
             a.legend(frameon=False, ncols=2)
 
     def plot_offsets(self):


### PR DESCRIPTION
This PR factors out the cross section and includes the XFEL polarization in the CookieboxCalibration, so that the polarization of the beam can be included in the transmission calculation.

The only API change is the inclusion of the `beta`, `P1` and `tilt` parameters in the constructor, which allows one to set the photo-electron angular dependence parametrization. The default setup corresponds to a standard configuration of horizontal polarization. They are also serialised to HDF5.