### PR TITLE
Increase bunch pattern table length to 4096

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -59,6 +59,8 @@ Changed:
 - [imshow2()][extra.utils.imshow2] will now add a colorbar automatically (!351).
 - [Calibration](calibration.md) conditions objects can now be displayed as
   Markdown in Jupyter notebooks (!381).
+- Increased maximal length of pulse masks returned by
+  [pulse_mask()][extra.components.pulses.PulsePattern.pulse_mask] to 4096 (!461).
 
 ## [2025.1]
 

--- a/src/extra/components/pulses.py
+++ b/src/extra/components/pulses.py
@@ -47,7 +47,8 @@ class PulsePattern:
     # System Specification, Version 2.2 (2013). The original table may
     # have up to 7222 entries at 9 MHz with the Karabo Timeserver device
     # only forwarding the even places at 4.5 MHz.
-    _bunch_pattern_table_len = 3611
+    # This was increasd from 3611 to 4096 entries during the LIMP 2025.
+    _bunch_pattern_table_len = 4096
 
     def __init__(self, source: SourceData = None, key: KeyData = None):
         self._source = source


### PR DESCRIPTION
This accomodates a change done do the underlying timing system in anticipation of longer train lengths enabled by GUN5.