### PR TITLE
Make Scan object from motor target positions

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -32,6 +32,9 @@ Added:
   next release, rather than only Python 3.10 (!377).
 - [Scan.group_data()][extra.components.Scan.group_data] method to make an xarray
   or pandas GroupBy object based on scan steps (!379).
+- [Scan.from_motor_targets()][extra.components.Scan.from_motor_targets] method
+  to make a scan object based on the target positions of the motor, excluding
+  points where the actual position is too far from the target.
 - [fit_gaussian()][extra.utils.fit_gaussian] has a new `nans_on_failure`
   argument to allow returning NaN arrays when fitting fails (!385).
 - [fit_gaussian()][extra.utils.fit_gaussian] now supports

--- a/src/extra/components/scan.py
+++ b/src/extra/components/scan.py
@@ -31,7 +31,7 @@ class Scan:
     ```
     """
 
-    def __init__(self, motor, name=None, resolution=None, min_trains=None, intra_step_filtering=1):
+    def __init__(self, motor, name=None, resolution=None, min_trains=None, intra_step_filtering=1, *, _steps=None):
         """The class tries to detect the best parameters automatically, but it will
         still fail in some situations. If that happens either the `resolution`
         or `min_trains` parameters (unlikely to be both) will need to be set
@@ -78,8 +78,8 @@ class Scan:
                 around a step.
         """
         self._steps = []
-        self._resolution = None
-        self._min_trains = None
+        self._resolution = resolution
+        self._min_trains = min_trains
         self._intra_step_filtering = intra_step_filtering
 
         # Debugging variables
@@ -107,17 +107,38 @@ class Scan:
 
         self._name = name if name is not None else default_name
 
-        steps = self._get_motor_steps(self._input_pos, resolution,
-                                      min_trains, intra_step_filtering)
+        if _steps is None:
+            steps = self._get_motor_steps(self._input_pos, resolution,
+                                          min_trains, intra_step_filtering)
 
-        # Sometimes motors that have jitter are erroneously detected as a
-        # single-step scan, so we ignore those and only take scans with more
-        # than 1 step detected.
-        if len(steps) > 1:
-            self._steps = steps
+            # Sometimes motors that have jitter are erroneously detected as a
+            # single-step scan, so we ignore those and only take scans with more
+            # than 1 step detected.
+            if len(steps) > 1:
+                self._steps = steps
+        else:
+            # From an alternative constructor, e.g. from_motor_targets()
+            self._steps = _steps
 
         self._positions = np.array([pos for pos, _ in self.steps])
         self._positions_train_ids = [tids for _, tids in self.steps]
+
+    @classmethod
+    def from_motor_targets(cls, motor: SourceData, tolerance, *, name=None):
+        target = motor['targetPosition'].xarray()
+        actual = motor['actualPosition'].xarray()
+
+        # Discard trains where actual is not close to target
+        target = target[np.absolute(target - actual) < tolerance]
+
+        # Steps defined by changes in target position
+        change_ixs = list(np.nonzero(np.diff(target))[0] + 1)
+        steps = [
+            (target[start].item(), target[start:stop].trainId.values.tolist())
+            for start, stop in zip([0] + change_ixs, change_ixs + [len(target)])
+        ]
+
+        return cls(actual, name=name, resolution=tolerance, _steps=steps)
 
     @property
     def name(self) -> str:

--- a/src/extra/components/scan.py
+++ b/src/extra/components/scan.py
@@ -211,7 +211,10 @@ class Scan:
                     line_x_max = max(left - 0.5 * width, min_tid)
                     line_x_min = max(left - 1.75 * width, min_tid)
                     ha = 'right'
-                ax.text(lbl_x, pos, str(i),
+
+                # clip_on ensures text is not drawn if outside the axis bounds
+                # https://discourse.matplotlib.org/t/axes-text-plotting-text-outside-of-axes-bounds/18419/3
+                ax.text(lbl_x, pos, str(i), clip_on=True,
                         verticalalignment='center_baseline', horizontalalignment=ha)
                 ax.plot([line_x_min, line_x_max], [pos, pos], color='k')
 

--- a/src/extra/components/scan.py
+++ b/src/extra/components/scan.py
@@ -125,6 +125,11 @@ class Scan:
 
     @classmethod
     def from_motor_targets(cls, motor: SourceData, tolerance, *, name=None):
+        """Make a Scan object based on the target positions of a motor
+
+        The steps are defined by the motor target positions. Points are only
+        included if the actual position is within *tolerance* of the target.
+        """
         target = motor['targetPosition'].xarray()
         actual = motor['actualPosition'].xarray()
 

--- a/src/extra/components/scan.py
+++ b/src/extra/components/scan.py
@@ -31,7 +31,7 @@ class Scan:
     ```
     """
 
-    def __init__(self, motor, name=None, resolution=None, min_trains=None, intra_step_filtering=1, *, _steps=None):
+    def __init__(self, motor, name=None, resolution=None, min_trains=None, intra_step_filtering=1, *, target=None):
         """The class tries to detect the best parameters automatically, but it will
         still fail in some situations. If that happens either the `resolution`
         or `min_trains` parameters (unlikely to be both) will need to be set
@@ -76,6 +76,10 @@ class Scan:
                 being to remove trains on the boundaries of a step. Try tweaking
                 this value if there are too many/too few trains being filtered
                 around a step.
+            target (KeyData, DataArray): Optional target positions of the
+                scanned motor. If passed, this will be used to determine steps,
+                and trains where the actual motor position (*motor* parameter)
+                differs by more than *resolution* are discarded.
         """
         self._steps = []
         self._resolution = resolution
@@ -107,7 +111,8 @@ class Scan:
 
         self._name = name if name is not None else default_name
 
-        if _steps is None:
+        if target is None:
+            # Original method: find steps in e.g. motor actualPosition
             steps = self._get_motor_steps(self._input_pos, resolution,
                                           min_trains, intra_step_filtering)
 
@@ -117,14 +122,30 @@ class Scan:
             if len(steps) > 1:
                 self._steps = steps
         else:
-            # From an alternative constructor, e.g. from_motor_targets()
-            self._steps = _steps
+            # Target positions given: find steps, then filter on target - actual
+            if isinstance(target, KeyData):
+                target = target.xarray()
+
+            if resolution is None:
+                target_diffs = np.diff(target)
+                mdn_step = np.median(np.abs(target_diffs[target_diffs != 0]))
+                self._resolution = resolution = 0.2 * mdn_step
+
+            # Discard trains where actual is not close to target
+            filtered = target[np.absolute(target - self._input_pos) < resolution]
+
+            # Steps defined by changes in target position
+            change_ixs = list(np.nonzero(np.diff(filtered))[0] + 1)
+            self._steps = [
+                (filtered[start].item(), filtered[start:stop].trainId.values)
+                for start, stop in zip([0] + change_ixs, change_ixs + [len(filtered)])
+            ]
 
         self._positions = np.array([pos for pos, _ in self.steps])
         self._positions_train_ids = [tids for _, tids in self.steps]
 
     @classmethod
-    def from_motor_targets(cls, motor: SourceData, tolerance, *, name=None):
+    def from_motor_targets(cls, motor: SourceData, *, tolerance=None, name=None):
         """Make a Scan object based on the target positions of a motor
 
         The steps are defined by the motor target positions. Points are only
@@ -133,17 +154,7 @@ class Scan:
         target = motor['targetPosition'].xarray()
         actual = motor['actualPosition'].xarray()
 
-        # Discard trains where actual is not close to target
-        target = target[np.absolute(target - actual) < tolerance]
-
-        # Steps defined by changes in target position
-        change_ixs = list(np.nonzero(np.diff(target))[0] + 1)
-        steps = [
-            (target[start].item(), target[start:stop].trainId.values)
-            for start, stop in zip([0] + change_ixs, change_ixs + [len(target)])
-        ]
-
-        return cls(actual, name=name, resolution=tolerance, _steps=steps)
+        return cls(actual, target=target, name=name, resolution=tolerance)
 
     @property
     def name(self) -> str:

--- a/src/extra/components/scan.py
+++ b/src/extra/components/scan.py
@@ -134,7 +134,7 @@ class Scan:
         # Steps defined by changes in target position
         change_ixs = list(np.nonzero(np.diff(target))[0] + 1)
         steps = [
-            (target[start].item(), target[start:stop].trainId.values.tolist())
+            (target[start].item(), target[start:stop].trainId.values)
             for start, stop in zip([0] + change_ixs, change_ixs + [len(target)])
         ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,6 +63,9 @@ def mock_spb_aux_directory():
             # 1 train at each transition between steps.
             motor_ds[:] = np.repeat(np.arange(10), 10)
             motor_ds[10::10] = np.arange(9) + 0.5
+            motor_target_ds = f['CONTROL/MOTOR/MCMOTORYFACE/targetPosition/value']
+            motor_target_ds[:] = np.repeat(np.arange(10), 10)
+
             # write agipd quadrand motor positions
             write_motor_positions(f, "SPB_IRU_AGIPD1M")
             # write jf4m halves motor positions

--- a/tests/test_components_scan.py
+++ b/tests/test_components_scan.py
@@ -1,12 +1,10 @@
-from extra.components import Scan
-
 import pytest
 import numpy as np
 import pandas as pd
 import xarray as xr
 
 import extra_data
-
+from extra.components import Scan
 
 def test_scan(mock_spb_aux_run):
     motor = mock_spb_aux_run["MOTOR/MCMOTORYFACE"]
@@ -146,3 +144,13 @@ def test_scan_group_data(mock_spb_aux_run):
     data_pd = pd.Series(np.zeros(len(pulse_midx)), index=pulse_midx)
     gb2 = s.group_data(data_pd)
     assert len(gb2) == len(s.positions)
+
+
+def test_scan_by_targets(mock_spb_aux_run):
+    scan = Scan.from_motor_targets(mock_spb_aux_run["MOTOR/MCMOTORYFACE"])
+    assert len(scan.positions) == 10
+    assert 0.01 < scan._resolution < 0.5
+    assert [len(tids) for tids in scan.positions_train_ids] == [10] + [9] * 9
+
+    # Smoke test
+    scan.plot()


### PR DESCRIPTION
This is a request from FXE: rather than defining a scan just from motor actual positions, which can be noisy, it can be convenient to define it based on target positions, which are in neat steps, and exclude points where the actual position is too far from the target.

This would be used like:

```python
scan = Scan.from_motor_targets(run['FXE_XTD9_MONO/MDL/ACCM_PITCH'], tolerance=1e-4)
```

<img width="935" height="653" alt="image" src="https://github.com/user-attachments/assets/885fa1a4-f4e0-4ce0-bd11-687d79622b0d" />

We could probably guess a default tolerance, e.g. 20% of the smallest step size, but for now I haven't tried to do this.

TBD: tests