### PR TITLE
StepTimer: Simple overview of what takes time

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -68,6 +68,7 @@ Added:
 - [TOFAnalogResponse][extra.applications.TOFAnalogResponse] can deconvolve the Auger-Meitner
   and photon line if the flag `deconvolve` is set to True.
   summary about a pulse pattern (!435).
+- `StepTimer` class for measuring performance within functions.
 
 Fixed:
 

--- a/src/extra/components/adq.py
+++ b/src/extra/components/adq.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from extra_data import by_id
 from extra_data.read_machinery import roi_shape, split_trains
+from ..utils.misc import StepTimer
 from .pulses import XrayPulses, PulsePattern
 from .utils import _isinstance_no_import
 from ._adq import _reshape_flat_pulses
@@ -1122,6 +1123,7 @@ class AdqRawChannel:
         Returns:
             data (xarray.DataArray or numpy.ndarray): Digitizer traces.
         """
+        timer = StepTimer("AdqRawChannel.pulse_data")
 
         if isinstance(train_roi, slice):
             # See comment in AdqChannel.train_data().
@@ -1146,6 +1148,7 @@ class AdqRawChannel:
             if isinstance(psh, pasha.ProcessContext) and out is not None:
                 raise TypeError("Cannot use out= with parallel processing")
             out = self._validate_out(out, out_shape, psh.alloc, dtype=dtype)
+            timer("setup")
 
             def read_pulses(wid, index, train_id, data):
                 layout_row = pulse_layout.loc[train_id]
@@ -1158,6 +1161,7 @@ class AdqRawChannel:
                     layout_row['length'])
 
             psh.map(read_pulses, raw_key)
+            timer("parallel read")
 
         else:
             # Prepare output buffers.
@@ -1166,6 +1170,7 @@ class AdqRawChannel:
             # Temporary buffer for a single iteration.
             tmp = np.zeros((200,) + roi_shape(
                 self._raw_key.entry_shape, train_roi), dtype=out.dtype)
+            timer("setup")
 
             for kd in raw_key.split_trains(trains_per_part=200):
                 pulse_sel = np.s_[pulse_layout.loc[kd.train_ids[0]]['first']:
@@ -1173,11 +1178,14 @@ class AdqRawChannel:
 
                 tmp_sel = tmp[:len(kd.train_ids)]
                 kd.ndarray(roi=train_roi, out=tmp_sel)
+                timer("load chunk")
 
                 self._preprocess(tmp_sel, tmp_sel)
+                timer("preprocess chunk")
                 self._reshape_flat_pulses(
                     tmp_sel, out[pulse_sel], pulse_ids[pulse_sel],
                     pulse_layout['length'].max())
+                timer("reshape chunk")
 
         if not labelled:
             return out

--- a/src/extra/utils/misc.py
+++ b/src/extra/utils/misc.py
@@ -1,8 +1,13 @@
 import sys
+from dataclasses import dataclass
+from time import perf_counter
+from typing import ClassVar, Self
 
 import numpy as np
 
 from typing import Any
+
+from pandas._libs.tslibs import timestamps
 
 
 def find_nearest_index(array, value: Any) -> np.int64:
@@ -56,6 +61,66 @@ def reorder_axes_to_shape(a, target_shape):
 
     order = tuple([a.shape.index(l) for l in t])
     return a.transpose(order)
+
+
+@dataclass
+class TimingResult:
+    name: str
+    timestamps: list[tuple[str, float]]
+    finish: float | None = None
+
+    @property
+    def step_times(self):
+        d = {}
+        prev_ts = self.timestamps[0][1]
+        for label, ts in self.timestamps[1:]:
+            d.setdefault(label, []).append(ts - prev_ts)
+            prev_ts = ts
+
+        return d
+
+    def _repr_markdown_(self):
+        lines = [f"**{self.name}** step timings:", ""]
+        for i, (label, dts) in enumerate(self.step_times.items(), start=1):
+            dt = np.mean(dts)
+            rpt = f"({len(dts)}×)" if len(dts) > 1 else ""
+            lines.append(f"{i}. {label}: {dt:.3g} s {rpt}")
+        if self.finish:
+            start = self.timestamps[0][1]
+            lines.extend(["", f"Total: {self.finish - start:.3g} s"])
+        return "\n".join(lines)
+
+
+class StepTimer:
+    latest: ClassVar[TimingResult | None] = None  # Store the latest timings
+    show = False  # Set True to show timings as they're recorded
+
+    def __init__(self, name: str):
+        ts = perf_counter()
+        self.results = TimingResult(name, [("start", ts)])
+        self.on_start(name, ts)
+
+    def __call__(self, label: str):
+        ts = perf_counter()
+
+        self.results.timestamps.append((label, ts))
+        self.on_step(label, ts - self.results.timestamps[-2][1])
+
+    def __del__(self):
+        self.results.finish = perf_counter()
+        StepTimer.latest = self.results
+        self.on_finish(self.results)
+
+    # The on_ methods are meant to be
+    def on_start(self, name, timestamp):
+        pass
+
+    def on_step(self, label, dt):
+        if self.show:
+            print(f"{label}: {dt:.3g} s")
+
+    def on_finish(self, results):
+        pass
 
 
 def _isinstance_no_import(obj, mod: str, cls: str):

--- a/src/extra/utils/misc.py
+++ b/src/extra/utils/misc.py
@@ -1,13 +1,11 @@
 import sys
 from dataclasses import dataclass
 from time import perf_counter
-from typing import ClassVar, Self
+from typing import ClassVar
 
 import numpy as np
 
 from typing import Any
-
-from pandas._libs.tslibs import timestamps
 
 
 def find_nearest_index(array, value: Any) -> np.int64:
@@ -126,6 +124,12 @@ class StepTimer:
 
         self.results.timestamps.append((label, ts))
         self.on_step(label, ts - self.results.timestamps[-2][1])
+
+    def __enter__(self):
+        return self  # No timestamp, we assume this is immediately after init
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self("with block finish")
 
     def __del__(self):
         self.results.finish = perf_counter()

--- a/src/extra/utils/misc.py
+++ b/src/extra/utils/misc.py
@@ -65,6 +65,7 @@ def reorder_axes_to_shape(a, target_shape):
 
 @dataclass
 class TimingResult:
+    """Results collected by StepTimer. Should display itself nicely."""
     name: str
     timestamps: list[tuple[str, float]]
     finish: float | None = None
@@ -90,8 +91,28 @@ class TimingResult:
             lines.extend(["", f"Total: {self.finish - start:.3g} s"])
         return "\n".join(lines)
 
+    def __repr__(self):
+        lines = [f"{self.name} step timings:", ""]
+        for i, (label, dts) in enumerate(self.step_times.items(), start=1):
+            dt = np.mean(dts)
+            rpt = f"({len(dts)}×)" if len(dts) > 1 else ""
+            lines.append(f"{i:3d}. {label}: \t{dt:.3g} s {rpt}")
+        if self.finish:
+            start = self.timestamps[0][1]
+            lines.extend(["", f"Total: {self.finish - start:.3g} s"])
+        return "\n".join(lines)
+
 
 class StepTimer:
+    """Measure step timings within a function or method.
+
+    Instantiate StepTimer() with the name of the thing being timed, then call
+    it at the end of each step with a label for that step.
+
+    Timings aren't shown by default, but StepTimer.latest gives the last
+    finished measurements, or set StepTimer.show=True to print timings as they
+    are measured. Override on_start, on_step & on_finish to do more.
+    """
     latest: ClassVar[TimingResult | None] = None  # Store the latest timings
     show = False  # Set True to show timings as they're recorded
 
@@ -113,13 +134,16 @@ class StepTimer:
 
     # The on_ methods are meant to be
     def on_start(self, name, timestamp):
+        """Overridable: called with timer name & start timestamp"""
         pass
 
     def on_step(self, label, dt):
+        """Overridable: called with step label and time since last call"""
         if self.show:
             print(f"{label}: {dt:.3g} s")
 
     def on_finish(self, results):
+        """Overridable: called with TimingResults object"""
         pass
 
 

--- a/src/extra/utils/misc.py
+++ b/src/extra/utils/misc.py
@@ -79,11 +79,16 @@ class TimingResult:
         return d
 
     def _repr_markdown_(self):
-        lines = [f"**{self.name}** step timings:", ""]
+        lines = [
+            f"**{self.name}** step timings:",
+            "",
+            "n  | step | total step time | repeats | average time",
+            "--|--|--|--|--"
+        ]
         for i, (label, dts) in enumerate(self.step_times.items(), start=1):
-            dt = np.mean(dts)
-            rpt = f"({len(dts)}×)" if len(dts) > 1 else ""
-            lines.append(f"{i}. {label}: {dt:.3g} s {rpt}")
+            dts = np.array(dts)
+            avg = f"{dts.mean():.3g} ± {dts.std():.3g} s" if len(dts) > 1 else ""
+            lines.append(f"{i} | {label} | {dts.sum():.3g} s | {len(dts)}× | {avg}")
         if self.finish:
             start = self.timestamps[0][1]
             lines.extend(["", f"Total: {self.finish - start:.3g} s"])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,7 @@ import xarray as xr
 
 from extra.utils import (
     imshow2, hyperslicer2, ridgeplot, fit_gaussian, gaussian, reorder_axes_to_shape,
+    StepTimer,
 )
 
 
@@ -103,3 +104,16 @@ def test_reorder_axes_to_shape():
     res = reorder_axes_to_shape(arr, (5, 3))
     assert res.shape == (5, 3)
     np.testing.assert_array_equal(res[0], [0, 5, 10])
+
+
+def test_steptimer():
+    with StepTimer("testing") as timer:
+        timer("label")
+
+    tr = timer.results
+    assert [l for l, _ in tr.timestamps] == ["start", "label", "with block finish"]
+    assert len(tr.step_times) == 2
+
+    # Smoke test
+    repr(tr)
+    tr._repr_markdown_()


### PR DESCRIPTION
I want to get a basic idea of what steps in a slow operation are taking time. Profilers can give much more detail, but also require more effort to use. The timer calls added here can be left in functions and methods (`perf_counter()` takes <100 ns), and you can look at the timings from the last call that used them:

<img width="372" height="210" alt="image" src="https://github.com/user-attachments/assets/52faa5d1-f6fa-4b2f-b9f0-b9e36ce24ee7" />

You instantiate `StepTimer` inside a function with a name for what it's timing, and then call it at the end of a step with a label for that step. Steps with the same label are displayed as repeats of the same step. The finish time is set when the timer goes out of scope.

You can also set `StepTimer.show = True` to print timings as they are collected, or replace the `on_(start|step|finish)` methods to e.g. send it to a log file or a database.