### PR TITLE
Bug fix: number of photo-electron counts.

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -74,6 +74,7 @@ Fixed:
   `uncertainty_method` parameter.
 - Fixed support for plotting images with zeros/negative numbers with
   [imshow2()][extra.utils.imshow2] and `lognorm=True` (!491).
+- Fixed counting threshold for `CookieboxCalibration` (!498).
 
 Changed:
 

--- a/src/extra/applications/cookiebox.py
+++ b/src/extra/applications/cookiebox.py
@@ -187,7 +187,7 @@ def calc_mean(itr: Tuple[int, int], scan: Scan, xgm_data: xr.DataArray, tof: Dic
         tof_data = tof[tof_id].select_trains(by_id[train_ids])
         tof_data = tof_data.pulse_edges(pulse_dim='pulseIndex', threshold=count_threshold).reset_index()
 
-        bins = np.arange(0, n_samples+1)
+        bins = np.arange(0, count_samples+1)
         out_data, _ = np.histogram(tof_data.edge, bins=bins, weights=-tof_data.amplitude)
 
         out_data = xr.DataArray(out_data, dims=('sample'), coords={'sample': bins[:-1]})


### PR DESCRIPTION
This is reminiscent of a previous PR, in which the variable names were adapted, but it seems this variable name was not changed.