### PR TITLE
Fix incomplete pulse alignment in new parallel paths of AdqRawChannel

### DIFF
--- a/src/extra/components/adq.py
+++ b/src/extra/components/adq.py
@@ -1056,7 +1056,7 @@ class AdqRawChannel:
                 out[index] = data[roi]
                 self._preprocess(out[index], out[index])
 
-            psh.map(read_train, self._raw_key)
+            psh.map(read_train, self._raw_key.drop_empty_trains())
         else:
             out = self._validate_out(out, shape)
 
@@ -1143,7 +1143,7 @@ class AdqRawChannel:
                     tmp_sel.reshape(1, -1), out[pulse_sel], pulse_ids[pulse_sel],
                     layout_row['length'])
 
-            psh.map(read_pulses, self._raw_key)
+            psh.map(read_pulses, raw_key)
 
         else:
             # Prepare output buffers.


### PR DESCRIPTION
Merging yesterday's MR https://github.com/European-XFEL/EXtra/pull/497 unfortunately introduces the already fixed alignment issues from https://github.com/European-XFEL/EXtra/pull/361 and https://github.com/European-XFEL/EXtra/pull/332. I'm still a bit mystified why the tests existing for this particular issue did not trigger, but I would like to have it fixed ASAP.