### PR TITLE
AdqRawChannel improvements

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,9 +20,12 @@ Added:
 
 - [TimeserverPulses.plot_xray_patterns][extra.components.pulses.TimeserverPulses.plot_xray_patterns]
   to visualize the X-ray pulse patterns present in timeserver data (!499).
-- [AdqRawChannel.train_data][extra.components.AdqRawChannel.pulse_data] and
-  [AdqRawChannel.train_data][extra.components.AdqRawChannel.pulse_data] are now
+- [AdqRawChannel.train_data][extra.components.AdqRawChannel.train_data] and
+  [AdqRawChannel.pulse_data][extra.components.AdqRawChannel.pulse_data] are now
   reading data in parallel by default (!497).
+- [AdqRawChannel.pulse_data][extra.components.AdqRawChannel.pulse_data] accepts
+  a dtype parameter for the output array.
+- [AdqRawChannel.split_trains][extra.components.AdqRawChannel.split_trains]
 - [AGIPDConditions][extra.calibration.AGIPDConditions] now recognizes current source constant types
 - [CalibrationData.from_data][extra.calibration.CalibrationData.from_data] method to
   find the constants suitable for a given `DataCollection`

--- a/src/extra/components/adq.py
+++ b/src/extra/components/adq.py
@@ -1054,8 +1054,11 @@ class AdqRawChannel:
 
         if parallel is not False:
             # Prepare parallelization.
+            import pasha
             psh = self._prepare_pasha(parallel)
 
+            if isinstance(psh, pasha.ProcessContext) and out is not None:
+                raise TypeError("Cannot use out= with parallel processing")
             out = self._validate_out(out, shape, psh.alloc)
 
             def read_train(wid, index, train_id, data):
@@ -1136,12 +1139,13 @@ class AdqRawChannel:
 
         if parallel is not False:
             # Prepare parallelization.
+            import pasha
             psh = self._prepare_pasha(parallel)
 
             # Prepare output buffers.
-            if out is not None:
-                raise ValueError("Cannot use output array with parallel processing")
-            out = self._validate_out(None, out_shape, psh.alloc, dtype=dtype)
+            if isinstance(psh, pasha.ProcessContext) and out is not None:
+                raise TypeError("Cannot use out= with parallel processing")
+            out = self._validate_out(out, out_shape, psh.alloc, dtype=dtype)
 
             def read_pulses(wid, index, train_id, data):
                 layout_row = pulse_layout.loc[train_id]

--- a/src/extra/components/adq.py
+++ b/src/extra/components/adq.py
@@ -328,13 +328,13 @@ class AdqRawChannel:
 
         return edge_func
 
-    def _validate_out(self, out, shape, alloc=np.zeros):
+    def _validate_out(self, out, shape, alloc=np.zeros, dtype=np.float32):
         """Validate output arguments."""
 
         is_corrected = self._cm_period > 0 or self._baselevel is not None
 
         if out is None:
-            out = alloc(shape, dtype=np.float32)
+            out = alloc(shape, dtype=dtype)
         elif any([a < b for a, b in zip(out.shape, shape)]):
             raise ValueError(f'requires at least output array shape {shape}')
         elif is_corrected and not np.issubdtype(out.dtype, np.floating):
@@ -1079,7 +1079,7 @@ class AdqRawChannel:
         return xr.DataArray(out, coords=coords)
 
     def pulse_data(self, labelled=True, pulse_dim='pulseId', train_roi=(),
-                   out=None, parallel=None):
+                   out=None, *, dtype=np.float32, parallel=None):
         """Load this channel's raw data by pulse.
 
         In addition to [AdqRawChannel.train_data], this method also
@@ -1103,6 +1103,8 @@ class AdqRawChannel:
                 performed. The entire train trace is read if omitted.
             out (numpy.typing.ArrayLike, optional): Array to read into,
                 a new one is allocated if omitted.
+            dtype: (numpy dtype specifier, optional): dtype to use for the
+                output array. Ignored if out is passed.
             parallel (int or None, optional): Number of parallel
                 processes to use, by default 10 or a quarter of all cores
                 whichever is lower. Any non-positive value or 1 disable
@@ -1131,7 +1133,9 @@ class AdqRawChannel:
             psh = self._prepare_pasha(parallel)
 
             # Prepare output buffers.
-            out = self._validate_out(None, out_shape, psh.alloc)
+            if out is not None:
+                raise ValueError("Cannot use output array with parallel processing")
+            out = self._validate_out(None, out_shape, psh.alloc, dtype=dtype)
 
             def read_pulses(wid, index, train_id, data):
                 layout_row = pulse_layout.loc[train_id]
@@ -1147,7 +1151,7 @@ class AdqRawChannel:
 
         else:
             # Prepare output buffers.
-            out = self._validate_out(out, out_shape)
+            out = self._validate_out(out, out_shape, dtype=dtype)
 
             # Temporary buffer for a single iteration.
             tmp = np.zeros((200,) + roi_shape(

--- a/src/extra/components/adq.py
+++ b/src/extra/components/adq.py
@@ -337,7 +337,8 @@ class AdqRawChannel:
             out = alloc(shape, dtype=dtype)
         elif any([a < b for a, b in zip(out.shape, shape)]):
             raise ValueError(f'requires at least output array shape {shape}')
-        elif is_corrected and not np.issubdtype(out.dtype, np.floating):
+
+        if is_corrected and not np.issubdtype(out.dtype, np.floating):
             from warnings import warn
             warn('Common mode correction or baselevel pull may yield '
                  'incorrect results with non-floating data types',

--- a/src/extra/components/adq.py
+++ b/src/extra/components/adq.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 
 from extra_data import by_id
-from extra_data.read_machinery import roi_shape
+from extra_data.read_machinery import roi_shape, split_trains
 from .pulses import XrayPulses, PulsePattern
 from .utils import _isinstance_no_import
 from ._adq import _reshape_flat_pulses
@@ -638,6 +638,11 @@ class AdqRawChannel:
             res._pulses = self._pulses.select_trains(trains)
 
         return res
+
+    def split_trains(self, parts=None, trains_per_part=None):
+        n_trains = len(self._instrument_src.train_ids)
+        for sl in split_trains(n_trains, parts=parts, trains_per_part=trains_per_part):
+            yield self.select_trains(sl)
 
     def samples_per_pulse(self, pulse_period=None, pulse_duration=None,
                           repetition_rate=None, pulse_ids=None,

--- a/tests/test_components_adq.py
+++ b/tests/test_components_adq.py
@@ -343,3 +343,9 @@ def test_pulse_edges(mock_sqs_remi_run):
     edges = ch.pulse_edges(threshold=0.5)
 
     assert edges.shape[0] < pulses.pulse_counts().sum()
+
+
+def test_split_trains(mock_sqs_remi_run):
+    ch = AdqRawChannel(mock_sqs_remi_run, "1C", digitizer='SQS_DIGITIZER_UTC2')
+    chunks = list(ch.split_trains(trains_per_part=30))
+    assert [len(c.instrument_source.train_ids) for c in chunks] == [25] * 4


### PR DESCRIPTION
- Allow specifying a dtype for `pulse_data` without specifying an entire output array - it needs a non-trivial amount of code to work out the correct output shape. We're disabling the common-mode correction, so keeping the data as int16 is faster than converting to float.
  - I wondered about making int16 the default when you're not using common-mode or baselevel, but I'm not convinced it's worth the API break.
  - We could also add the parameter for `train_data`? But it's not so important because the shape is easier to work out.
- Add a `.split_trains()` method to split the AdqRawChannel into chunks - this is something we want because we reduce the data immediately after loading, so doing it piece by piece avoids a big spike in memory usage.
