### PR TITLE
Add PulsePattern.inspect()

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,8 +18,9 @@
 
 Added:
 
-- [PumpProbePattern.pumped_pulses_ratios()][extra.components.PumpProbePattern.pumped_pulses_ratios]
+- [PumpProbePattern.pumped_pulses_ratios][extra.components.PumpProbePattern.pumped_pulses_ratios]
   determining the ratio of pumped pulses per train (!317).
+- [PulsePattern.inspect][extra.components.pulses.PulsePattern.inspect] to visualize any pulse patterns (!504).
 - [TimeserverPulses.plot_xray_patterns][extra.components.pulses.TimeserverPulses.plot_xray_patterns]
   to visualize the X-ray pulse patterns present in timeserver data (!499).
 - [DelayLineDetector.edges][extra.components.DelayLineDetector.edges] can include the edge amplitudes

--- a/docs/components/pulse-patterns.md
+++ b/docs/components/pulse-patterns.md
@@ -93,3 +93,5 @@ for a single SASE, instrument or device is called *pulse index*. If desired, the
 ::: extra.components.DldPulses
     options:
 		inherited_members: false
+
+::: extra.components.plot_pulse_grid

--- a/docs/components/pulse-patterns.md
+++ b/docs/components/pulse-patterns.md
@@ -7,19 +7,20 @@ also resolves every or at least some of the underlying pulses a train is compose
 ![European XFEL timing structure](../images/trains_pulses.png){ width="75%" align=center }
 
 The `PulsePattern` family of components allows access to pulse patterns recorded
-by various sources. For example, in order to obtain the FEL pulses for a particular
-SASE:
+by various sources. For example, in order to obtain the FEL pulses recorded by the timeserver
+for a particular SASE:
 
 ```python
 p = XrayPulses(run)
 p.pulse_ids()
 ```
 
-There are different types available depending on the source that should be used for
-the pulse pattern information, but they all offer the same interface as
-[`PulsePattern`][extra.components.pulses.PulsePattern] for access. Furthermore,
-many other components like [`AdqRawChannel`][extra.components.AdqRawChannel] can be
-given a [`PulsePattern`][extra.components.pulses.PulsePattern] component to customize
+There are different pulse pattern types that use different information to build a pulse
+pattern or interpret it in a different way listed further below. They all offer the same
+basic interface of [`PulsePattern`][extra.components.pulses.PulsePattern] for access with
+additional methods somtimes provided for specialized operations. Furthermore, many other
+components like [`AdqRawChannel`][extra.components.AdqRawChannel] can receive a
+[`PulsePattern`][extra.components.pulses.PulsePattern] component to customize
 how pulse-resolved data is interpreted.
 
 The primary source of pulse pattern information is the bunch pattern table from
@@ -68,23 +69,23 @@ for a single SASE, instrument or device is called *pulse index*. If desired, the
 
 ::: extra.components.pulses.TimeserverPulses
 	options:
-		inherited_members: no
+		inherited_members: false
 
 ::: extra.components.XrayPulses
 	options:
-		inherited_members: no
+		inherited_members: false
 
 ::: extra.components.OpticalLaserPulses
 	options:
-		inherited_members: no
+		inherited_members: false
 
 ::: extra.components.PumpProbePulses
 	options:
-		inherited_members: no
+		inherited_members: false
 
 ::: extra.components.MachinePulses
 	options:
-		inherited_members: no
+		inherited_members: false
 
 ::: extra.components.ManualPulses
     options:

--- a/src/extra/components/__init__.py
+++ b/src/extra/components/__init__.py
@@ -1,7 +1,7 @@
 
 from .scantool import Scantool  # noqa
 from .pulses import XrayPulses, OpticalLaserPulses, MachinePulses, \
-    PumpProbePulses, ManualPulses, DldPulses  # noqa
+    PumpProbePulses, ManualPulses, DldPulses, plot_pulse_grid  # noqa
 from .scan import Scan  # noqa
 from .xgm import XGM  # noqa
 from .dld import DelayLineDetector  # noqa

--- a/src/extra/components/pulses.py
+++ b/src/extra/components/pulses.py
@@ -78,8 +78,8 @@ def _select_pulse_ids(pulse_ids, pulse_sel, train_sel):
 
             def slice_pulses(pulse_ids):
                 return pulse_ids[(pulse_ids > start) &
-                                    (pulse_ids < stop) &
-                                    (pulse_ids % step == start % step)]
+                                 (pulse_ids < stop) &
+                                 (pulse_ids % step == start % step)]
 
         elif isinstance(pulse_sel.value, (list, np.ndarray)):
             new_pulse_ids = pulse_sel.value
@@ -538,7 +538,7 @@ class PulsePattern:
 
         rates = self.pulse_repetition_rates().dropna()
         if rates.empty:
-            print(f' Repetition rate: no pulses')
+            print(' Repetition rate: no pulses')
         elif len(rates.unique()) == 1:
             print(f' Repetition rate: {_format_rate(rates.iloc[0])}')
         else:
@@ -557,7 +557,7 @@ class PulsePattern:
 
         durations = self.train_durations().dropna()
         if durations.empty:
-            print(f' Train duration: no pulses')
+            print(' Train duration: no pulses')
         elif len(durations.unique()) == 1:
             print(f' Train duration: {_format_duration(durations.iloc[0])}')
         else:
@@ -638,7 +638,8 @@ class PulsePattern:
 
         The possible options for pulse selection are:
 
-        - By pulse index using `extra_data.by_index` with a slice, list or ndarray:
+        - By pulse index using `extra_data.by_index` with a slice, list
+          or ndarray:
             ```
             by_index[5:]  # All pulses after the first five.
             by_index[[0, 1, 2]]  # Explicitly the first three pulses.
@@ -776,7 +777,7 @@ class PulsePattern:
 
         index = pd.MultiIndex.from_arrays(
             [np.repeat(act_train_ids, pulse_counts),
-            np.concatenate([np.arange(num) for num in pulse_counts])],
+             np.concatenate([np.arange(num) for num in pulse_counts])],
             names=['trainId', 'pulseIndex'])
 
         new_pulse_ids = pd.Series(np.concatenate(new_pulse_ids), index=index)
@@ -928,7 +929,6 @@ class PulsePattern:
         else:
             return True
 
-
     def is_interleaved_with(self, other: PulsePattern) -> Optional[bool]:
         """Check whether pulses are interleaved with other pattern.
 
@@ -1033,8 +1033,7 @@ class PulsePattern:
         # Minimum of difference between pulses in a train by train.
         act_periods = (self.pulse_ids(copy=False)
             .groupby(level=0).diff()  # Periods within each train.
-            .groupby(level=0).min()  # Minimal period in each train.
-        )
+            .groupby(level=0).min())  # Minimal period in each train.
 
         # Fill any NaN value with a fill value.
         single_pulse_periods = act_periods.isna()
@@ -1586,10 +1585,8 @@ class TimeserverPulses(PulsePattern):
                 if (pids := np.flatnonzero(mask)).size == 0:
                     continue
 
-                ax.vlines(pids,
-                        i * (b/2) + i * d,
-                        i * (b/2) + i * d + b,
-                        color=f'C{i}', lw=1.0, alpha=count/total)
+                ax.vlines(pids, i * (b/2) + i * d, i * (b/2) + i * d + b,
+                          color=f'C{i}', lw=1.0, alpha=count/total)
 
                 min_pids[i] = min(min_pids[i], pids.min())
                 max_pids[i] = max(max_pids[i], pids.max())
@@ -2185,7 +2182,6 @@ class PumpProbePulses(XrayPulses, OpticalLaserPulses):
 
         train_ids = self._get_train_ids()
         pulse_ids = self.pulse_ids(copy=False)
-        pids_by_train = pulse_ids.groupby(level=0)
 
         if reduced:
             pid_offset = pulse_ids.min()
@@ -2427,7 +2423,7 @@ class ManualPulses(PulsePattern):
         """
 
         if repetition_rate is not None:
-            pulse_period = int(round(1.3e9 / 288 / repetition_rate , 0))
+            pulse_period = int(round(1.3e9 / 288 / repetition_rate, 0))
         elif pulse_period is None:
             raise ValueError('must specify either repetition_rate or '
                              'pulse_period')

--- a/src/extra/components/pulses.py
+++ b/src/extra/components/pulses.py
@@ -126,6 +126,244 @@ def _select_pulse_ids(pulse_ids, pulse_sel, train_sel):
         'trainId', group_keys=False).apply(slice_pulses)
 
 
+def _get_pulse_weights(pids):
+    """Return relative weights and occuring pulse IDs."""
+
+    unique_pids, counts = np.unique(pids.groupby('trainId').apply(tuple),
+                                    return_counts=True)
+    total = counts.sum()
+
+    weights = np.zeros(pids.max()+1, dtype=np.float64)
+    for pids_set, count in zip(unique_pids, counts):
+        weights[np.array(pids_set)] += count/total
+
+    act_pids = np.flatnonzero(weights)
+
+    return weights, act_pids
+
+
+def plot_pulse_grid(main_pulses=None, marker_pulses=None, border_pulses=None,
+                    main_label=None, marker_label=None, border_label=None,
+                    start=None, stop=None, num_cols=None,
+                    figsize=(9, 9), ax=None):
+    """Visualize pulse pattern in a grid.
+
+    Plots up to three pulse pattern in a grid, with each grid cell
+    representing a possible pulse location at 4.5 MHz. The available
+    visualizations are the cell's background color, a marker within each
+    cell and the border around cells. In all cases, variable patterns
+    are represented by levels of transparency weighted by their rate of
+    occurence in the data.
+
+    Args:
+        main_pulses (PulsePattern or pd.Series, optional): Pulses to
+            visualize as colored cells in the grid.
+        maarker_pulses (PulsePattern or pd.Series, optional): Pulses
+            to visualize as markers inside the grid's cells.
+        border_pulses (PulsePattern or pd.Series, optional): Pulses
+            to visualize as borders of the grid's cells.
+        main_label (str, optional): Legend label for main pulses,
+            none if omitted.
+        marker_label (str, optional): Legend label for marker pulses,
+            none if omitted.
+        border_label (str, optional): Legend label for border pulses,
+            none if omitted.
+        start (int, optional): Lowest pulse ID to include, picked
+            automatically based on data by default.
+        stop (int, optional): Highest pulse ID to include, picked
+            automatically based on data by default.
+        num_cols (int, optional): Number of pulse columns to use, picked
+            automatically based on data by default.
+        figsize (2-tuple of float, optional): Figure size in inches
+            passed to matplotlib, ignored if ax is passed. This only
+            describes the outer boundaries depending on the plot's
+            aspect ratio.
+        ax (matplotlib.axes.Axes, optional): Axes object to plot into,
+            created automatically if omitted.
+
+    Returns:
+        ax (matplotlib.axes.Axes): Axes object the plot was
+            generated in.
+    """
+
+    if ax is None:
+        import matplotlib.pyplot as plt
+        fig, ax = plt.subplots(figsize=figsize)
+
+    if isinstance(main_pulses, PulsePattern):
+        main_pids = main_pulses.pulse_ids(copy=False)
+    elif isinstance(main_pulses, pd.Series):
+        main_pids = main_pulses
+    elif main_pulses is not None:
+        raise TypeError(f'main_pulses must be PulsePattern or labeled '
+                        f'series not `{type(main_pulses).__name__}`')
+
+    if isinstance(marker_pulses, PulsePattern):
+        marker_pids = marker_pulses.pulse_ids(copy=False)
+    elif isinstance(marker_pulses, pd.Series):
+        marker_pids = marker_pulses
+    elif marker_pulses is not None:
+        raise TypeError(f'marker_pulses must be PulsePattern or labeled '
+                        f'series, not `{type(marker_pulses).__name__}`')
+
+    if isinstance(border_pulses, PulsePattern):
+        border_pids = border_pulses.pulse_ids(copy=False)
+    elif isinstance(border_pulses, pd.Series):
+        border_pids = border_pulses
+    elif border_pulses is not None:
+        raise TypeError(f'border_pulses must be PulsePattern or labeled '
+                        f'series, not `{type(border_pulses).__name__}`')
+
+    pids = []
+
+    if main_pulses is not None:
+        pids.append(main_pids)
+
+    if marker_pulses is not None:
+        pids.append(marker_pids)
+
+    if border_pulses is not None:
+        pids.append(border_pids)
+
+    if not pids:
+        raise ValueError('must specify at least one pulse pattern')
+
+    # Determine pulse ID boundaries and plot limits based on it, if
+    # not given explicitly.
+    min_pid = start if start is not None else \
+        min([x.min() for x in pids])
+    max_pid = stop if stop is not None else \
+        max([x.max() for x in pids])
+    pid_range = max_pid - min_pid
+
+    if np.isfinite(pid_range):
+        # If not given explicitly, find a column number that is a
+        # multiple of 10 between 20 and 50.
+        num_cols = num_cols or (np.clip(pid_range // 10, 20, 50) // 10) * 10
+
+        start_row = max(min_pid // num_cols, 0)
+        if start is None:
+            start_row -= 1  # Add one more row if autoscaling.
+
+        stop_row = int(np.ceil(max_pid // num_cols)) + 1
+        if stop is None:
+            stop_row += 1  # Add one row if autoscaling.
+    else:
+        # In case there are no pulses at all.
+        num_cols = num_cols or 32
+        start_row = 0
+        stop_row = 3
+
+    # Pulse ID shown in the top-left and bottom-right corners.
+    start_pid = start_row * num_cols
+    stop_pid = stop_row * num_cols
+
+    from matplotlib.cm import Blues, Oranges
+    from matplotlib.collections import LineCollection
+    from matplotlib.colors import ListedColormap
+    from matplotlib.lines import Line2D
+    from matplotlib.patches import Patch
+    from matplotlib.ticker import MaxNLocator, AutoMinorLocator, \
+        StrMethodFormatter, FuncFormatter
+    from matplotlib.transforms import offset_copy
+
+    # Build the grid in X, Y and Z.
+    Y, X = np.mgrid[start_row:(stop_row+1), :(num_cols+1)]
+    Z = np.zeros(stop_pid - start_pid, dtype=np.float64)
+
+    # Project colormap onto 256 values and replace the first with white.
+    colors = Blues(np.linspace(0, 1, 256))
+    colors[0] = [1.0, 1.0, 1.0, 1.0]
+    cmap = ListedColormap(colors)
+
+    # Collect custom legend handles for each plotted pulse pattern.
+    legend_handles = []
+
+    if main_pulses is not None and not main_pids.empty:
+        # If specified, render main pulses into Z values.
+        weights, act_pids = _get_pulse_weights(main_pids)
+        Z[act_pids - start_pid] = weights[act_pids]
+
+    if main_label is not None:
+        # If specified, generate a custom legend handle for main pulses.
+        legend_handles.append(Patch(fc=cmap(0.6), ec='k', lw=0.1,
+                                    label=main_label))
+
+    ax.pcolor(X - 0.5, Y - 0.5,
+              Z.reshape(stop_row - start_row, num_cols),
+              cmap=cmap, vmin=0, vmax=1.5*Z.max(),
+              edgecolors='k', lw=0.1)
+
+    if marker_pulses is not None and not marker_pids.empty:
+        # If specified, render marker pulses as a scatter plot on top of
+        # the grid.
+        weights, act_pids = _get_pulse_weights(marker_pids)
+        ax.scatter(act_pids % num_cols, act_pids // num_cols, lw=2,
+                   c=Oranges(0.1 + 0.5*weights[act_pids]), marker='.')
+
+    if marker_label is not None:
+        # If specified, generate a custom legend handle for markers.
+        legend_handles.append(Line2D([0], [0], ls='none', marker='.', ms=10,
+                                     color=Oranges(0.6), label=marker_label))
+
+    if border_pulses is not None and not border_pids.empty:
+        # If specified, render border pulses as a line collection of
+        # rectangles enclosing grid points.
+
+        weights, act_pids = _get_pulse_weights(border_pids)
+        X = np.add.outer(act_pids % num_cols, [-0.5, +0.5, +0.5, -0.5, -0.5])
+        Y = np.add.outer(act_pids // num_cols, [-0.5, -0.5, +0.5, +0.5, -0.5])
+        XY = np.stack([X, Y], axis=2)
+
+        ax.add_collection(LineCollection(
+            XY, colors=Oranges(0.65 * weights[act_pids]), lw=2))
+
+    if border_label is not None:
+        # If specified, generate a custom legend handle for borders.
+        legend_handles.append(Patch(fc='none', ec=Oranges(0.65), lw=2,
+                                    label=border_label))
+
+    # Invert the plot by default.
+    ax.invert_yaxis()
+
+    # Build X axis as offset to Y axis in terms of pulse ID.
+    ax.set_xlim(-0.5, num_cols - 0.5)
+    ax.xaxis.set_major_locator(MaxNLocator(
+        nbins=10, steps=[5, 10], integer=True))
+    ax.xaxis.set_major_formatter(StrMethodFormatter('+{x:.0f}'))
+    ax.xaxis.set_minor_locator(AutoMinorLocator())
+
+    ax.yaxis.set_major_locator(MaxNLocator(nbins='auto', integer=True))
+    ax.yaxis.set_major_formatter(FuncFormatter(
+        lambda x, pos: f'{x*num_cols:.0f}'))
+    ax.set_yticks(np.arange(start_row, stop_row), minor=True)
+
+    # Add a custom grid in X and Y.
+    for x in ax.get_xticks()[1:-1]:
+        ax.plot([x - 0.5, x - 0.5], [start_row - 0.5, stop_row - 0.5],
+                'k', lw=0.25)
+
+    for y in ax.get_yticks()[1:-1]:
+        ax.plot([-0.5, num_cols + 0.5], [y - 0.5, y - 0.5], 'k', lw=0.25)
+
+    # General plot setup.
+    ax.set_aspect(1)
+    ax.tick_params(axis='both', labelsize=8)
+
+    # Add legend if there are any labels.
+    if legend_handles:
+        # Offet axes transform in absolute units to position legend
+        # indepedently of plot height.
+        legend_transform = offset_copy(ax.transAxes, fig=ax.get_figure(),
+                                       y=22, units='points')
+
+        ax.legend(handles=legend_handles, ncols=len(legend_handles),
+                  loc='upper left', bbox_transform=legend_transform,
+                  bbox_to_anchor=(0.0, 1.0), borderaxespad=0.0)
+
+    return ax
+
+
 class PulsePattern:
     """Abstract interface to pulse patterns.
 

--- a/src/extra/components/pulses.py
+++ b/src/extra/components/pulses.py
@@ -569,6 +569,27 @@ class PulsePattern:
         else:
             print(' Variable pattern')
 
+    def inspect(self, **plot_kwargs):
+        """Visualize pulse pattern in a grid.
+
+        Plots the pulse pattern this object describes for this data in
+        a grid, with each grid point representing a possible pulse
+        location at 4.5 MHz.
+
+        Args:
+            **edge_kw (Any): Any further keyword arguments are passed to
+                [plot_pulse_grid()][extra.components.pulses.plot_pulse_grid].
+
+        Returns:
+            ax (matplotlib.axes.Axes): Axes object the plot was
+                generated in.
+        """
+
+        ax = plot_pulse_grid(self, **plot_kwargs)
+        ax.set_title(f'{repr(self)}', fontsize='medium')
+
+        return self
+
     def select_trains(self, trains):
         """Select a subset of trains.
 
@@ -2198,6 +2219,43 @@ class PumpProbePulses(XrayPulses, OpticalLaserPulses):
 
         return flags
 
+    def inspect(self, **plot_kwargs):
+        """Visualize pulse pattern in a grid.
+
+        Plots the pulse pattern this object describes for this data in
+        a grid, with each grid point representing a possible pulse
+        location at 4.5 MHz. FEL pulses are represented by each cell's
+        background color, while PPL pulses are denoted by each cell's
+        border.
+
+        Args:
+            **edge_kw (Any): Any further keyword arguments are passed to
+                [plot_pulse_grid()][extra.components.pulses.plot_pulse_grid].
+
+        Returns:
+            ax (matplotlib.axes.Axes): Axes object the plot was
+                generated in.
+        """
+
+        pids = self.pulse_ids(copy=False)
+
+        plot_kwargs = dict(main_label='FEL', border_label='PPL') | plot_kwargs
+
+        try:
+            plot_kwargs['main_pulses'] = pids.xs(True, level='fel')
+        except KeyError:
+            pass
+
+        try:
+            plot_kwargs['border_pulses'] = pids.xs(True, level='ppl')
+        except KeyError:
+            pass
+
+        ax = plot_pulse_grid(**plot_kwargs)
+        ax.set_title(f'{repr(self)}', fontsize='small', pad=30)
+
+        return ax
+
     def pulse_mask(self, labelled=True, field=None):
         """Get boolean pulse mask.
 
@@ -2479,6 +2537,46 @@ class DldPulses(PulsePattern):
                 // (self._clock_ratio or 196) + (self._first_pulse_id or 0)
 
         return pd.Series(data=pulse_ids, index=index, dtype=np.int32)
+
+    def inspect(self, **plot_kwargs):
+        """Visualize pulse pattern in a grid.
+
+        Plots the pulse pattern this object describes for this data in
+        a grid, with each grid point representing a possible pulse
+        location at 4.5 MHz. FEL pulses are represented by each cell's
+        background color, while PPL pulses are denoted by each cell's
+        border.
+
+        Args:
+            **edge_kw (Any): Any further keyword arguments are passed to
+                [plot_pulse_grid()][extra.components.pulses.plot_pulse_grid].
+
+        Returns:
+            ax (matplotlib.axes.Axes): Axes object the plot was
+                generated in.
+        """
+
+        pids = self.pulse_ids(copy=False)
+
+        if 'fel' not in pids.index.names:
+            return super().plot_grid()
+
+        plot_kwargs = dict(main_label='FEL', border_label='PPL') | plot_kwargs
+
+        try:
+            plot_kwargs['main_pulses'] = pids.xs(True, level='fel')
+        except KeyError:
+            pass
+
+        try:
+            plot_kwargs['border_pulses'] = pids.xs(True, level='ppl')
+        except KeyError:
+            pass
+
+        ax = plot_pulse_grid(**plot_kwargs)
+        ax.set_title(f'{repr(self)}', fontsize='small', pad=30)
+
+        return ax
 
     def triggers(self, labelled=True):
         """Get trigger information.

--- a/tests/test_components_pulses.py
+++ b/tests/test_components_pulses.py
@@ -11,7 +11,7 @@ from euxfel_bunch_pattern import PPL_BITS, DESTINATION_TLD, DESTINATION_T5D, \
     PHOTON_LINE_DEFLECTION
 from extra.data import RunDirectory, SourceData, KeyData, by_index, by_id
 from extra.components import XrayPulses, OpticalLaserPulses, MachinePulses, \
-    PumpProbePulses, ManualPulses, DldPulses
+    PumpProbePulses, ManualPulses, DldPulses, plot_pulse_grid
 
 from .mockdata import assert_equal_sourcedata, assert_equal_keydata
 
@@ -943,3 +943,19 @@ def test_union_pulses():
     np.testing.assert_array_equal(
         p.pulse_ids(),
         2 * [100, 102, 104] + [100, 102, 103, 104, 105] + 2 * [100, 103, 105])
+
+
+def test_plot_pulse_grid():
+    p = ManualPulses.from_constant_pattern([1, 2, 3], 5, pulse_period=1)
+
+    for kind in ['main', 'marker', 'border']:
+        plot_pulse_grid(**{f'{kind}_pulses': p, f'{kind}_label': kind})
+        plot_pulse_grid(**{f'{kind}_pulses': p.pulse_ids()})
+
+        with pytest.raises(TypeError):
+            plot_pulse_grid(**{f'{kind}_pulses': p.pulse_ids(labelled=False)})
+
+    plot_pulse_grid(ManualPulses.from_constant_pulses([], []))
+
+    with pytest.raises(ValueError):
+        plot_pulse_grid()

--- a/tests/test_components_pulses.py
+++ b/tests/test_components_pulses.py
@@ -199,6 +199,18 @@ def test_is_interleaved(mock_spb_aux_run, source):
 
 
 @pytest.mark.parametrize('source', **pattern_sources)
+def test_inspect(mock_spb_aux_run, source):
+    pulses = XrayPulses(mock_spb_aux_run, source=source)
+
+    import matplotlib.pyplot as plt
+
+    # Smoke tests
+    pulses.inspect()
+    pulses.inspect(figsize=(5, 3))
+    pulses.inspect(ax=plt.subplots()[1])
+
+
+@pytest.mark.parametrize('source', **pattern_sources)
 def test_plot_xray_patterns(mock_spb_aux_run, source):
     pulses = XrayPulses(mock_spb_aux_run, source=source)
 
@@ -603,6 +615,9 @@ def test_dld_pulses(capsys):
     assert pulse_ids.index.names == ['trainId', 'pulseIndex', 'fel', 'ppl']
     np.testing.assert_equal(pulse_ids, triggers['pulse'])
 
+    # Smoke-test inspect.
+    pulses.inspect()
+
     counts = pulses.pulse_counts()
     np.testing.assert_equal(counts, np.array([10]))
 
@@ -662,6 +677,9 @@ def test_pump_probe_basic(mock_spb_aux_run, source):
 
     pulses = PumpProbePulses(run.select_trains(np.s_[10:]),
                              source=source, pulse_offset=1)
+
+    # Smoke testing inspect().
+    pulses.inspect()
 
     # Pulse IDs.
     pids = pulses.pulse_ids()


### PR DESCRIPTION
This is the second part after https://github.com/European-XFEL/EXtra/pull/499 to add basic visualization for any pulse pattern, here inspired by the common online diagnostics already in Karabo with some tweaks for better offline compatibility.

This is meant to only cover the base implementation in `PulsePattern`, with advanced implementations like `PumpProbePulses` customizing this with their specialized data.

<img width="861" height="295" alt="image" src="https://github.com/user-attachments/assets/4265f7cc-1828-4d5a-8fdf-6621d2ea4d0b" />


