### PR TITLE
Add amplitude support to DelayLineDetector.edges()

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,8 @@ Added:
 
 - [TimeserverPulses.plot_xray_patterns][extra.components.pulses.TimeserverPulses.plot_xray_patterns]
   to visualize the X-ray pulse patterns present in timeserver data (!499).
+- [DelayLineDetector.edges][extra.components.DelayLineDetector.edges] can include the edge amplitudes
+  in its result if requested (!505).
 - [AdqRawChannel.train_data][extra.components.AdqRawChannel.train_data] and
   [AdqRawChannel.pulse_data][extra.components.AdqRawChannel.pulse_data] are now
   reading data in parallel by default (!497).

--- a/src/extra/components/dld.py
+++ b/src/extra/components/dld.py
@@ -5,7 +5,7 @@ import re
 import numpy as np
 import pandas as pd
 
-from extra.data import KeyData
+from extra.data import KeyData, PropertyNameError
 from .utils import _isinstance_no_import
 
 
@@ -312,44 +312,61 @@ class DelayLineDetector:
 
         return self.pulses().triggers()
 
-    def edges(self, channel_index=True, pulse_dim='pulseId'):
+    def edges(self, channel_index=True, amplitudes=False, pulse_dim='pulseId'):
         """Get raw edges as series or dataframe.
 
         Args:
             channel_index (bool, optional): Whether to insert the edge
-                channel as index level and return Series object
-                (default), or as column and return DataFrame object.
+                channel as index level (default), or as column. The
+                latter will cause the method to return a DataFrame
+                rather a Series.
+            amplitudes (bool, optional): Whether to insert amplitudes as
+                a column. This will cause the method to return a
+                DataFrame rather than a Series.
             pulse_dim ('pulseId' or 'pulseIndex' or 'pulseTime', optional):
                 Label for pulse dimension, pulse ID by default.
 
         Returns:
             edges (pd.Series or pd.DataFrame): Raw edge positions as
-                series (indexed by channel) or dataframe (with channel
-                as column) object.
+                a dataframe when channel is added as column and/or
+                amplitudes ar eincluded, otherwise a series.
         """
 
         kd = self._instrument_src['raw.edges']
-        index = self._align_pulse_index(kd, pulse_dim)
+        pulse_index = self._align_pulse_index(kd, pulse_dim)
         data = kd.ndarray()
-        raw_edges = [self._build_reduced_pd(data[:, i, :], index)
-                     for i in range(data.shape[1])]
+        raw_edges = [self._build_reduced_pd(data[:, i, :], pulse_index)
+                    for i in range(data.shape[1])]
 
-        index = pd.MultiIndex.from_frame(
+        edge_index = pd.MultiIndex.from_frame(
             pd.concat([e.index.to_frame() for e in raw_edges]))
         positions = np.concatenate([e.to_numpy() for e in raw_edges])
         channels = np.arange(len(raw_edges)).repeat(
             [len(e) for e in raw_edges])
 
-        edges = pd.DataFrame(dict(position=positions, channel=channels),
-                             index=index)
+        columns = dict(channel=channels, position=positions)
+
+        if amplitudes:
+            try:
+                data = self._instrument_src['raw.amplitudes'].ndarray()
+            except PropertyNameError:
+                raise ValueError('amplitudes not available in data') from None
+
+            columns['amplitude'] = np.concatenate([
+                self._build_reduced_pd(data[:, i, :], pulse_index).to_numpy()
+                for i in range(data.shape[1])])
+
+        edges = pd.DataFrame(columns, index=edge_index)
         edges.sort_values(by='position', inplace=True)
         edges.sort_index(inplace=True)
 
         if channel_index:
             edges.set_index('channel', drop=True, append=True, inplace=True)
-            return edges['position']
-        else:
-            return edges
+
+            if not amplitudes:
+                return edges['position']
+
+        return edges
 
     def signals(self, pulse_dim='pulseId', extra_columns={}, max_method=None):
         """Get reconstructed signals as dataframe.

--- a/tests/mockdata/dld.py
+++ b/tests/mockdata/dld.py
@@ -11,6 +11,7 @@ trigger_dt = np.dtype([('start', np.int32), ('stop', np.int32),
                        ('fel', bool), ('ppl', bool)])
 
 edge_dt = np.dtype('f8')
+amplitude_dt = np.dtype('f8')
 
 hit_dt = np.dtype([('x', np.float64), ('y', np.float64),
                    ('t', np.float64), ('m', np.int32)], align=True)
@@ -33,7 +34,8 @@ class ReconstructedDld(DeviceBase):
 
     instrument_keys = {
         'raw': [('triggers', trigger_dt, ()),
-                ('edges', edge_dt, (7, max_rows))],
+                ('edges', edge_dt, (7, max_rows)),
+                ('amplitudes', amplitude_dt, (7, max_rows))],
         'rec': [('signals', signal_dt, (max_rows,)),
                 ('hits', hit_dt, (max_rows,))],
     }
@@ -87,13 +89,16 @@ class ReconstructedDld(DeviceBase):
 
         data_root['raw/triggers'][:num_entries] = triggers
         data_root['raw/edges'][:num_entries] = np.nan
+        data_root['raw/amplitudes'][:num_entries] = np.nan
         data_root['rec/signals'][:num_entries] = np.nan
         data_root['rec/hits'][:num_entries] = (np.nan, np.nan, np.nan, -1)
 
         for i, ch in product(range(5), range(7)):
             # Alternate between 1-channel edges per pulse with random
             # values in [0, 1] + (7-channel).
-            data_root['raw/edges'][i:num_entries:7, ch, :ch+1] = (7 - ch)  \
+            data_root['raw/edges'][i:num_entries:7, ch, :ch+1] = (7 - ch) \
+                + 0.5 + np.random.rand(1 + (num_entries - i - 1) // 7, ch+1)
+            data_root['raw/amplitudes'][i:num_entries:7, ch, :ch+1] = (7 - ch) \
                 + 0.5 + np.random.rand(1 + (num_entries - i - 1) // 7, ch+1)
 
         for i in range(5):

--- a/tests/test_components_dld.py
+++ b/tests/test_components_dld.py
@@ -39,12 +39,15 @@ def test_dld_init(mock_sqs_remi_run):
     assert 'digitizer.baseline_region' in dld.rec_params
 
 
-@pytest.mark.parametrize('pulse_dim', ['pulseId', 'pulseIndex', 'time'])
+@pytest.mark.parametrize('pulse_dim', ['pulseId', 'pulseIndex', 'pulseTime'])
 @pytest.mark.parametrize('channel_index', [True, False],
                          ids=['channelIndex', 'channelColumn'])
-def test_dld_edges(mock_sqs_remi_run, pulse_dim, channel_index):
+@pytest.mark.parametrize('amplitudes', [False, True],
+                         ids=['withoutAmplitudes', 'withAmplitudes'])
+def test_dld_edges(mock_sqs_remi_run, pulse_dim, channel_index, amplitudes):
     dld = DelayLineDetector(mock_sqs_remi_run, 'SQS_REMI_DLD6/DET/TOP')
-    edges = dld.edges(channel_index=channel_index, pulse_dim=pulse_dim)
+    edges = dld.edges(channel_index=channel_index, amplitudes=amplitudes,
+                      pulse_dim=pulse_dim)
 
     # There should be 28 edges per pulse.
     assert np.all(edges.groupby(['trainId', pulse_dim]).count() == 28)
@@ -60,7 +63,17 @@ def test_dld_edges(mock_sqs_remi_run, pulse_dim, channel_index):
     np.testing.assert_equal(actual_channels[:28], expected_channels)
 
 
-@pytest.mark.parametrize('pulse_dim', ['pulseId', 'pulseIndex', 'time'])
+def test_dld_no_amplitudes(mock_sqs_remi_run):
+    # Exclude raw.amplitudes from data.
+    subrun = mock_sqs_remi_run.select(
+        'SQS_REMI_DLD6/DET/TOP:output', '*.[eths]*')
+    dld = DelayLineDetector(subrun, 'SQS_REMI_DLD6/DET/TOP')
+
+    with pytest.raises(ValueError):
+        dld.edges(amplitudes=True)
+
+
+@pytest.mark.parametrize('pulse_dim', ['pulseId', 'pulseIndex', 'pulseTime'])
 @pytest.mark.parametrize('key', ['signal', 'hit'])
 def test_dld_df(mock_sqs_remi_run, key, pulse_dim):
     from .mockdata import dld as dld_mockdata


### PR DESCRIPTION
For a while now, reconstructed DLD data also includes the amplitudes of discriminated edges in the `raw.amplitudes` key. This PR adds support to `DelayLineDetector.edges()` to include this data alongside edge positions, if requested.