### PR TITLE
Speed up CookieboxCalibration and TOFAnalogResponse and use `AdqRawChannel` parallelization when possible

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -110,6 +110,9 @@ Changed:
 - [CookieboxCalibration][extra.applications.CookieboxCalibration] calculates the transmission
   using the sum of the trace instead of the fit amplitude for robustness.
 - `extra.applications.base.SerializableMixin._fromdict` becomes a classmethod.
+- [CookieboxCalibration][extra.applications.CookieboxCalibration] and
+  [TOFAnalogResponse][extra.applications.TOFAnalogResponse] delegate
+  parallelization to the `AdqRawChannel` class (!509).
 
 ## [2025.1]
 

--- a/src/extra/applications/cookiebox.py
+++ b/src/extra/applications/cookiebox.py
@@ -138,7 +138,9 @@ def calc_mean(itr: Tuple[int, int], scan: Scan, xgm_data: xr.DataArray, tof: Dic
               xgm_threshold: float,
               count_threshold: float=None,
               correction_fn=None,
-              count_samples: int=500) -> xr.DataArray:
+              count_samples: int=500,
+              parallel: int=10,
+              ) -> xr.DataArray:
     """
     Calculate the mean of the ToF data in the given tof and energy bin in `itr`.
 
@@ -151,6 +153,7 @@ def calc_mean(itr: Tuple[int, int], scan: Scan, xgm_data: xr.DataArray, tof: Dic
       count_threshold: Number of ADU counts used to trigger photon count.
       correction_fn: A correction function to apply in the raw spectra.
       count_samples: Number of samples to consider when counting.
+      parallel: Number of threads to use when reading data in parallel.
 
     Returns: DataArray with mean of data in the energy bin given.
     """
@@ -169,7 +172,7 @@ def calc_mean(itr: Tuple[int, int], scan: Scan, xgm_data: xr.DataArray, tof: Dic
             x = tof[tof_id].select_trains(np._[0:1]).pulse_data(pulse_dim='pulseIndex').to_numpy().mean(0)
             return np.zeros_like(x), 0
         tof_data = tof[tof_id].select_trains(by_id[good_ids])
-        tof_data = tof_data.pulse_data(pulse_dim='pulseIndex')
+        tof_data = tof_data.pulse_data(pulse_dim='pulseIndex', parallel=parallel)
 
         good_ids = sorted(list(set(good_ids).intersection(set(tof_data.trainId.to_numpy()))))
         mask = xgm_data.coords["trainId"].isin(good_ids)
@@ -185,7 +188,7 @@ def calc_mean(itr: Tuple[int, int], scan: Scan, xgm_data: xr.DataArray, tof: Dic
         # in this case, ignore the XGM, as it is only used for cleaning the data
         # and here we rely on the threshold for that
         tof_data = tof[tof_id].select_trains(by_id[train_ids])
-        tof_data = tof_data.pulse_edges(pulse_dim='pulseIndex', threshold=count_threshold).reset_index()
+        tof_data = tof_data.pulse_edges(pulse_dim='pulseIndex', threshold=count_threshold, parallel=parallel).reset_index()
 
         bins = np.arange(0, count_samples+1)
         out_data, _ = np.histogram(tof_data.edge, bins=bins, weights=-tof_data.amplitude)
@@ -727,6 +730,7 @@ class CookieboxCalibration(SerializableMixin):
             correction_fn = {tof_id:
                              partial(self.fast_response_correction, tof_id=tof_id)
                              for tof_id in tof_ids}
+        parallel = self.parallel
         fn = partial(calc_mean,
                      scan=self._scan,
                      xgm_data=self._xgm_data,
@@ -735,34 +739,17 @@ class CookieboxCalibration(SerializableMixin):
                      count_threshold=self._count_threshold,
                      count_samples=self._count_samples,
                      correction_fn=correction_fn,
+                     parallel=parallel,
                      )
-        parallel = self.parallel
-        if correction_fn is not None:
-            parallel = False # correction function has in-build parallelism
-
-
-        if parallel:
-            with ProcessPoolExecutor(max_workers=10) as p:
-                itr_gen = list(itertools.product(tof_ids, energy_ids))
-                #data_gen = map(fn, itr_gen)
-                data_gen = p.map(fn, itr_gen)
-                # organize it all in a numpy array
-                for (d, x), (tof_id, energy_id) in zip(data_gen, itr_gen):
-                    data[tof_id] += [d]
-                    mean_xgm[tof_id] += [x]
-                for tof_id in tof_ids:
-                    data[tof_id] = np.stack(data[tof_id], axis=0)
-                    mean_xgm[tof_id] = np.stack(mean_xgm[tof_id], axis=0)
-        else:
-            itr_gen = list(itertools.product(tof_ids, energy_ids))
-            data_gen = map(fn, itr_gen)
-            # organize it all in a numpy array
-            for (d, x), (tof_id, energy_id) in zip(data_gen, itr_gen):
-                data[tof_id] += [d]
-                mean_xgm[tof_id] += [x]
-            for tof_id in tof_ids:
-                data[tof_id] = np.stack(data[tof_id], axis=0)
-                mean_xgm[tof_id] = np.stack(mean_xgm[tof_id], axis=0)
+        itr_gen = list(itertools.product(tof_ids, energy_ids))
+        data_gen = map(fn, itr_gen)
+        # organize it all in a numpy array
+        for (d, x), (tof_id, energy_id) in zip(data_gen, itr_gen):
+            data[tof_id] += [d]
+            mean_xgm[tof_id] += [x]
+        for tof_id in tof_ids:
+            data[tof_id] = np.stack(data[tof_id], axis=0)
+            mean_xgm[tof_id] = np.stack(mean_xgm[tof_id], axis=0)
 
         self.calibration_data = data
         self.calibration_mean_xgm = mean_xgm

--- a/src/extra/applications/cookiebox.py
+++ b/src/extra/applications/cookiebox.py
@@ -139,7 +139,7 @@ def calc_mean(itr: Tuple[int, int], scan: Scan, xgm_data: xr.DataArray, tof: Dic
               count_threshold: float=None,
               correction_fn=None,
               count_samples: int=500,
-              parallel: int=10,
+              parallel: Optional[int]=None,
               ) -> xr.DataArray:
     """
     Calculate the mean of the ToF data in the given tof and energy bin in `itr`.
@@ -354,7 +354,6 @@ class CookieboxCalibration(SerializableMixin):
       start_roi: Start of the RoI in a pulse, relative to the `first_pulse_offset`.
                  Use `None` to guess it.
       stop_roi: End of the RoI, relative to the `first_pulse_offset`. Use `None` to guess it.
-      parallel: Whether to average the input data in parallel.
       beta: Beta parameter.
             For l=0 electrons, set to 2 for linear polarization, 0 to circular polarization.
       tilt: Tilt angle for linear or elliptical polarization.
@@ -372,7 +371,6 @@ class CookieboxCalibration(SerializableMixin):
                  start_roi: Optional[int]=None,
                  stop_roi: Optional[int]=None,
                  interleaved: Optional[bool]=None,
-                 parallel: bool=True,
                  beta: float=2.0,
                  tilt: float=0.0,
                  P1: float=1.0,
@@ -382,7 +380,6 @@ class CookieboxCalibration(SerializableMixin):
         self._init_auger_start_roi = auger_start_roi
         self._init_start_roi = start_roi
         self._init_stop_roi = stop_roi
-        self.parallel = parallel
         self.beta = beta
         self.tilt = tilt
         self.P1 = P1
@@ -423,7 +420,6 @@ class CookieboxCalibration(SerializableMixin):
                             #"sources",
                             "calibration_energies",
                             "_tof_response",
-                            "parallel",
                             "beta",
                             "tilt",
                             "P1",
@@ -471,6 +467,7 @@ class CookieboxCalibration(SerializableMixin):
               scan: Scan,
               xgm: XGM,
               tof_response: Dict[int, TOFAnalogResponse]=None,
+              parallel=None
               ):
         """
         Derive calibrations.
@@ -487,6 +484,7 @@ class CookieboxCalibration(SerializableMixin):
           xgm: The XGM object used to apply a pulse energy selection.
                For example: `XGM(run, "SQS_DIAG1_XGMD/XGM/DOOCS")`
           tof_response: The response function object for deconvolution if that is desired.
+          parallel: Whether to paralellize data reading.
         """
         # base properties
         self._run = run
@@ -682,13 +680,16 @@ class CookieboxCalibration(SerializableMixin):
             self.kwargs_adq[tof_id]["name"] = self._tof[tof_id].name
         self.mask = {tof_id: True for tof_id in self.kwargs_adq.keys()}
 
-    def update_roi(self):
+    def update_roi(self, parallel=None):
         """
         Given calibrated data, apply a selection and find RoI if needed.
+
+        Args:
+          parallel: Number of threads to use if parallelizing data reading.
         """
         # average data for each energy slice
         logging.info("Reading calibration data ... (this takes a while)")
-        self.select_calibration_data()
+        self.select_calibration_data(parallel)
         # find RoI if needed
         if (self.auger_start_roi is None
             or self.start_roi is None
@@ -722,7 +723,7 @@ class CookieboxCalibration(SerializableMixin):
     def fast_response_correction(self, x, tof_id):
         return self._tof_response[tof_id].apply(x.fillna(0.0), method="nn_matrix", n_iter=100, nonneg=True)
 
-    def select_calibration_data(self):
+    def select_calibration_data(self, parallel=None):
         """
         Select data for calibration.
         """
@@ -735,7 +736,6 @@ class CookieboxCalibration(SerializableMixin):
             correction_fn = {tof_id:
                              partial(self.fast_response_correction, tof_id=tof_id)
                              for tof_id in tof_ids}
-        parallel = self.parallel
         fn = partial(calc_mean,
                      scan=self._scan,
                      xgm_data=self._xgm_data,

--- a/src/extra/applications/cookiebox.py
+++ b/src/extra/applications/cookiebox.py
@@ -516,7 +516,7 @@ class CookieboxCalibration(SerializableMixin):
         self.update_metadata()
 
         # find RoI if needed
-        self.update_roi()
+        self.update_roi(parallel)
 
         # find where the peaks are per energy in each Tof
         self.update_fit_result()

--- a/src/extra/applications/cookiebox.py
+++ b/src/extra/applications/cookiebox.py
@@ -167,22 +167,26 @@ def calc_mean(itr: Tuple[int, int], scan: Scan, xgm_data: xr.DataArray, tof: Dic
         # this does train ID matching, because:
         # - the given run may not have both XGM and eTOF for every train;
         # - and we cannot control the creation of the run object, since we want to receive the ready-made XGM object
-        good_ids = sorted(list(set(train_ids).intersection(set(xgm_data.trainId.data))))
+        good_ids = train_ids
+        if xgm_threshold > 0:
+            good_ids = np.intersect1d(train_ids, xgm_data.trainId.data)
         if len(good_ids) == 0:
             x = tof[tof_id].select_trains(np._[0:1]).pulse_data(pulse_dim='pulseIndex').to_numpy().mean(0)
             return np.zeros_like(x), 0
         tof_data = tof[tof_id].select_trains(by_id[good_ids])
         tof_data = tof_data.pulse_data(pulse_dim='pulseIndex', parallel=parallel)
 
-        good_ids = sorted(list(set(good_ids).intersection(set(tof_data.trainId.to_numpy()))))
-        mask = xgm_data.coords["trainId"].isin(good_ids)
-        sel_xgm_data = xgm_data[mask]
         # select XGM
-        tof_data = tof_data.loc[sel_xgm_data > xgm_threshold, :]
-        tof_xgm_data = sel_xgm_data.loc[sel_xgm_data > xgm_threshold]
+        if xgm_threshold > 0:
+            mask = xgm_data.coords["trainId"].isin(good_ids)
+            sel_xgm_data = xgm_data[mask]
+            tof_data = tof_data.loc[sel_xgm_data > xgm_threshold, :]
+            tof_xgm_data = sel_xgm_data.loc[sel_xgm_data > xgm_threshold]
 
         out_data = -tof_data.mean('pulse')
-        out_xgm = tof_xgm_data.mean('pulse')
+        out_xgm = 0.0
+        if xgm_threshold > 0:
+            out_xgm = tof_xgm_data.mean('pulse').to_numpy()
     else:
         # option 2: count photon peaks
         # in this case, ignore the XGM, as it is only used for cleaning the data
@@ -194,13 +198,14 @@ def calc_mean(itr: Tuple[int, int], scan: Scan, xgm_data: xr.DataArray, tof: Dic
         out_data, _ = np.histogram(tof_data.edge, bins=bins, weights=-tof_data.amplitude)
 
         out_data = xr.DataArray(out_data, dims=('sample'), coords={'sample': bins[:-1]})
-        out_xgm = xgm_data.mean('pulse')
+        out_xgm = 0.0
+        if xgm_threshold > 0:
+            out_xgm = xgm_data.mean('pulse').to_numpy()
 
     if correction_fn is not None:
         out_data = correction_fn[tof_id](out_data)
 
     out_data = out_data.to_numpy()
-    out_xgm = out_xgm.to_numpy()
 
     return out_data, out_xgm
 
@@ -362,7 +367,7 @@ class CookieboxCalibration(SerializableMixin):
       count_samples: If using photon counting (`count_threshold < 0`), use this many samples to obtain the spectrum.
     """
     def __init__(self,
-                 xgm_threshold: Union[str, float]='median',
+                 xgm_threshold: Union[str, float]=0.0,
                  auger_start_roi: Optional[int]=None,
                  start_roi: Optional[int]=None,
                  stop_roi: Optional[int]=None,

--- a/src/extra/applications/cookiebox_deconvolve.py
+++ b/src/extra/applications/cookiebox_deconvolve.py
@@ -470,7 +470,7 @@ class TOFAnalogResponse(SerializableMixin):
             else:
                 # count photo-electrons by histogramming peak positions
                 for k, e in enumerate(scan.positions):
-                    tof_data = tof.pulse_edges(pulse_dim='pulseIndex', threshold=self.count_threshold, parallel=self.parallel).reset_index()
+                    tof_data = tof.select_trains(by_id[scan.positions_train_ids[k]]).pulse_edges(pulse_dim='pulseIndex', threshold=self.count_threshold, parallel=self.parallel).reset_index()
                     this_tof_data, _ = np.histogram(tof_data.edge, bins=bins, weights=-tof_data.amplitude)
                     this_tof_data = xr.DataArray(this_tof_data, dims=('sample'), coords={'sample': bins[:-1]})
                 if self.roi is not None:

--- a/src/extra/applications/cookiebox_deconvolve.py
+++ b/src/extra/applications/cookiebox_deconvolve.py
@@ -362,6 +362,7 @@ class TOFAnalogResponse(SerializableMixin):
       n_filter: Number of samples before the peak to select.
       deconvolve: Whether to deconvolve the effect of two added peaks (ie: Auger-Meitner and monochromated photoline).
       count_threshold: If set, counts number of photo-electrons above this threshold. Should be negative.
+      parallel: How many threads to use for reading data in parallel.
     """
     def __init__(self,
                  roi: Optional[slice]=None,
@@ -369,6 +370,7 @@ class TOFAnalogResponse(SerializableMixin):
                  n_filter: int=100,
                  deconvolve: bool=False,
                  count_threshold: float=0,
+                 parallel=10,
                  ):
         self.roi = roi
         self.n_samples = n_samples
@@ -376,6 +378,7 @@ class TOFAnalogResponse(SerializableMixin):
         self.h = None
         self.deconvolve = deconvolve
         self.count_threshold = count_threshold
+        self.parallel = parallel
         self._version = 2
         self._all_fields = [
                             "h",
@@ -384,6 +387,7 @@ class TOFAnalogResponse(SerializableMixin):
                             "n_filter",
                             "deconvolve",
                             "count_threshold",
+                            "parallel",
                             "_version",
                            ]
 
@@ -460,13 +464,13 @@ class TOFAnalogResponse(SerializableMixin):
         if scan is not None: # use the scan
             # if not counting photo-electrons -- ie: analog mode
             if self.count_threshold is None or self.count_threshold >= 0:
-                this_tof_data = -tof.pulse_data(pulse_dim="pulseIndex").unstack("pulse")
+                this_tof_data = -tof.pulse_data(pulse_dim="pulseIndex", parallel=self.parallel).unstack("pulse")
                 for k, e in enumerate(scan.positions):
                     data += [this_tof_data.sel(trainId=scan.positions_train_ids[k]).mean("trainId").mean("pulseIndex").to_numpy()]
             else:
                 # count photo-electrons by histogramming peak positions
                 for k, e in enumerate(scan.positions):
-                    tof_data = tof.pulse_edges(pulse_dim='pulseIndex', threshold=self.count_threshold).reset_index()
+                    tof_data = tof.pulse_edges(pulse_dim='pulseIndex', threshold=self.count_threshold, parallel=self.parallel).reset_index()
                     this_tof_data, _ = np.histogram(tof_data.edge, bins=bins, weights=-tof_data.amplitude)
                     this_tof_data = xr.DataArray(this_tof_data, dims=('sample'), coords={'sample': bins[:-1]})
                 if self.roi is not None:
@@ -474,9 +478,9 @@ class TOFAnalogResponse(SerializableMixin):
                 data += [this_tof_data.to_numpy()]
         else:
             if self.count_threshold is None or self.count_threshold >= 0:
-                this_tof_data = -tof.pulse_data(pulse_dim="pulseIndex").mean('pulse')
+                this_tof_data = -tof.pulse_data(pulse_dim="pulseIndex", parallel=self.parallel).mean('pulse')
             else:
-                tof_data = tof.pulse_edges(pulse_dim='pulseIndex', threshold=self.count_threshold).reset_index()
+                tof_data = tof.pulse_edges(pulse_dim='pulseIndex', threshold=self.count_threshold, parallel=self.parallel).reset_index()
                 this_tof_data, _ = np.histogram(tof_data.edge, bins=bins, weights=-tof_data.amplitude)
                 this_tof_data = xr.DataArray(this_tof_data, dims=('sample'), coords={'sample': bins[:-1]})
             if self.roi is not None:

--- a/src/extra/applications/cookiebox_deconvolve.py
+++ b/src/extra/applications/cookiebox_deconvolve.py
@@ -362,7 +362,6 @@ class TOFAnalogResponse(SerializableMixin):
       n_filter: Number of samples before the peak to select.
       deconvolve: Whether to deconvolve the effect of two added peaks (ie: Auger-Meitner and monochromated photoline).
       count_threshold: If set, counts number of photo-electrons above this threshold. Should be negative.
-      parallel: How many threads to use for reading data in parallel.
     """
     def __init__(self,
                  roi: Optional[slice]=None,
@@ -370,7 +369,6 @@ class TOFAnalogResponse(SerializableMixin):
                  n_filter: int=100,
                  deconvolve: bool=False,
                  count_threshold: float=0,
-                 parallel=10,
                  ):
         self.roi = roi
         self.n_samples = n_samples
@@ -378,7 +376,6 @@ class TOFAnalogResponse(SerializableMixin):
         self.h = None
         self.deconvolve = deconvolve
         self.count_threshold = count_threshold
-        self.parallel = parallel
         self._version = 2
         self._all_fields = [
                             "h",
@@ -387,7 +384,6 @@ class TOFAnalogResponse(SerializableMixin):
                             "n_filter",
                             "deconvolve",
                             "count_threshold",
-                            "parallel",
                             "_version",
                            ]
 
@@ -443,7 +439,8 @@ class TOFAnalogResponse(SerializableMixin):
 
     def setup(self,
               tof: AdqRawChannel,
-              scan: Scan=None
+              scan: Scan=None,
+              parallel: int=None
               ):
         """
         Given a [AdqRawChannel][extra.components.AdqRawChannel] object, and an energy scan object
@@ -453,6 +450,7 @@ class TOFAnalogResponse(SerializableMixin):
         Args:
           tof: `AdqRawChannel` used to access data for a given eTOF.
           scan: `Scan` used to detect which regions cotain which energies.
+          parallel: How many threads to use for reading data in parallel.
         """
 
         # get pulse data
@@ -464,13 +462,13 @@ class TOFAnalogResponse(SerializableMixin):
         if scan is not None: # use the scan
             # if not counting photo-electrons -- ie: analog mode
             if self.count_threshold is None or self.count_threshold >= 0:
-                this_tof_data = -tof.pulse_data(pulse_dim="pulseIndex", parallel=self.parallel).unstack("pulse")
+                this_tof_data = -tof.pulse_data(pulse_dim="pulseIndex", parallel=parallel).unstack("pulse")
                 for k, e in enumerate(scan.positions):
                     data += [this_tof_data.sel(trainId=scan.positions_train_ids[k]).mean("trainId").mean("pulseIndex").to_numpy()]
             else:
                 # count photo-electrons by histogramming peak positions
                 for k, e in enumerate(scan.positions):
-                    tof_data = tof.select_trains(by_id[scan.positions_train_ids[k]]).pulse_edges(pulse_dim='pulseIndex', threshold=self.count_threshold, parallel=self.parallel).reset_index()
+                    tof_data = tof.select_trains(by_id[scan.positions_train_ids[k]]).pulse_edges(pulse_dim='pulseIndex', threshold=self.count_threshold, parallel=parallel).reset_index()
                     this_tof_data, _ = np.histogram(tof_data.edge, bins=bins, weights=-tof_data.amplitude)
                     this_tof_data = xr.DataArray(this_tof_data, dims=('sample'), coords={'sample': bins[:-1]})
                 if self.roi is not None:
@@ -478,9 +476,9 @@ class TOFAnalogResponse(SerializableMixin):
                 data += [this_tof_data.to_numpy()]
         else:
             if self.count_threshold is None or self.count_threshold >= 0:
-                this_tof_data = -tof.pulse_data(pulse_dim="pulseIndex", parallel=self.parallel).mean('pulse')
+                this_tof_data = -tof.pulse_data(pulse_dim="pulseIndex", parallel=parallel).mean('pulse')
             else:
-                tof_data = tof.pulse_edges(pulse_dim='pulseIndex', threshold=self.count_threshold, parallel=self.parallel).reset_index()
+                tof_data = tof.pulse_edges(pulse_dim='pulseIndex', threshold=self.count_threshold, parallel=parallel).reset_index()
                 this_tof_data, _ = np.histogram(tof_data.edge, bins=bins, weights=-tof_data.amplitude)
                 this_tof_data = xr.DataArray(this_tof_data, dims=('sample'), coords={'sample': bins[:-1]})
             if self.roi is not None:

--- a/tests/test_applications_cookiebox.py
+++ b/tests/test_applications_cookiebox.py
@@ -371,11 +371,12 @@ def test_no_parallel(mock_sqs_etof_calibration_run, tmp_path, mock_etof_mono_ene
                     auger_start_roi=1,
                     start_roi=75,
                     stop_roi=320,
-                    parallel=False,
     )
     cal.setup(run=mock_sqs_etof_calibration_run, energy_axis=energy_axis, tof_settings=tof_channel,
               xgm=xgm,
-              scan=scan)
+              scan=scan,
+              parallel=False,
+              )
 
     correct_energies = np.unique(mock_etof_mono_energies)
     correct_constants = np.array(mock_etof_calibration_constants)


### PR DESCRIPTION
The applications that depend on `AdqRawChannel` have now switched to use the inherent parallelization there. This simplifies the software, makes it more maintainable and achieves higher speeds, as I/O is the main reason for the slow processing.

Additionally, this speeds up the processing further by:
1. Using `np.intersect1d` which is faster than using `intersect` on sets.
2. Only calculating the mean pulse energy if a selection is applied.

Other changes using standard maps instead of `ProcessPoolExecutor` remove parallel processing from this code, as it could then compete with the parallel processing in `AdqRawChannel`.
