### PR TITLE
TOFAnalogResponse: use thresholding to obtain a background-free response function

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -116,7 +116,7 @@ Changed:
 - [CookieboxCalibration][extra.applications.CookieboxCalibration] and
   [TOFAnalogResponse][extra.applications.TOFAnalogResponse] delegate
   parallelization to the `AdqRawChannel` class (!509).
-- [TOFAnalogResponse][extra.applications.TOFAnalogResponse] average analog pulses using thresholding
+- [TOFAnalogResponse][extra.applications.TOFAnalogResponse] averages analog pulses using thresholding
   from `AdqRawChannel` to clean up the data (!511).
 
 ## [2025.1]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -116,6 +116,8 @@ Changed:
 - [CookieboxCalibration][extra.applications.CookieboxCalibration] and
   [TOFAnalogResponse][extra.applications.TOFAnalogResponse] delegate
   parallelization to the `AdqRawChannel` class (!509).
+- [TOFAnalogResponse][extra.applications.TOFAnalogResponse] average analog pulses using thresholding
+  from `AdqRawChannel` to clean up the data (!511).
 
 ## [2025.1]
 

--- a/src/extra/applications/cookiebox_deconvolve.py
+++ b/src/extra/applications/cookiebox_deconvolve.py
@@ -487,13 +487,13 @@ class TOFAnalogResponse(SerializableMixin):
                 logging.info("Calling pulse_edges ...")
                 tof_data = tof.pulse_edges(pulse_dim='pulseIndex', threshold=self.count_threshold, parallel=parallel).reset_index()
                 good_trains = np.unique(tof_data.loc[:,'trainId'].to_numpy())
-                idx = tof_data.loc[:, ['trainId', 'pulseIndex']].set_index(['trainId', 'pulseIndex']).idx
+                idx = tof_data.loc[:, ['trainId', 'pulseIndex']].set_index(['trainId', 'pulseIndex']).index
                 logging.info("Summing good trains ...")
                 analog_data = -tof.select_trains(by_id[good_trains]).pulse_data(pulse_dim="pulseIndex", parallel=parallel)
                 this_tof_data = analog_data.sel(pulse=idx)
-            if self.roi is not None:
-                this_tof_data = this_tof_data.isel(sample=self.roi)
-            data += [this_tof_data.to_numpy()]
+                if self.roi is not None:
+                    this_tof_data = this_tof_data.isel(sample=self.roi)
+                data += [this_tof_data.to_numpy()]
 
         for d in data:
             this_h = self.shift_h(d, h_axis)

--- a/src/extra/applications/cookiebox_deconvolve.py
+++ b/src/extra/applications/cookiebox_deconvolve.py
@@ -459,7 +459,7 @@ class TOFAnalogResponse(SerializableMixin):
         idx = tof_data.loc[:, ['trainId', 'pulseIndex']].set_index(['trainId', 'pulseIndex']).index
         logging.info("Summing good trains ...")
         # select only trains with a photo-electron detected ("good trains") to do this faster
-        analog_data = -tof.select_trains(by_id[good_trains]).pulse_data(pulse_dim="pulseIndex", parallel=parallel)
+        analog_data = -tof_part.select_trains(by_id[good_trains]).pulse_data(pulse_dim="pulseIndex", parallel=parallel)
         # select the train-pulses of interest
         this_tof_data = analog_data.sel(pulse=idx).mean("pulse")
         # apply an roi

--- a/src/extra/applications/cookiebox_deconvolve.py
+++ b/src/extra/applications/cookiebox_deconvolve.py
@@ -491,9 +491,9 @@ class TOFAnalogResponse(SerializableMixin):
                 logging.info("Summing good trains ...")
                 analog_data = -tof.select_trains(by_id[good_trains]).pulse_data(pulse_dim="pulseIndex", parallel=parallel)
                 this_tof_data = analog_data.sel(pulse=idx)
-                if self.roi is not None:
-                    this_tof_data = this_tof_data.isel(sample=self.roi)
-                data += [this_tof_data.to_numpy()]
+            if self.roi is not None:
+                this_tof_data = this_tof_data.isel(sample=self.roi)
+            data += [this_tof_data.to_numpy()]
 
         for d in data:
             this_h = self.shift_h(d, h_axis)

--- a/src/extra/applications/cookiebox_deconvolve.py
+++ b/src/extra/applications/cookiebox_deconvolve.py
@@ -437,6 +437,35 @@ class TOFAnalogResponse(SerializableMixin):
         this_h = np.interp(h_axis, xi, this_h)
         return this_h
 
+    def _count_photo_electrons(self, tof_part, parallel):
+        """
+        Given an `AdqRawChannel` object with monochromated data, count photo-electrons
+        and build a response function.
+
+        Args:
+          tof_part: The `AdqRawChannel` object to use for counting the electrons.
+          parallel: Argument used to parallelize `pulse_edges`.
+
+        Returns: The response function aligned to this monochromated peak.
+        """
+        logging.info("Calling pulse_edges for selected trains ...")
+        # get peak positions where photo-electrons were found
+        tof_data = tof_part.pulse_edges(pulse_dim='pulseIndex',
+                                        threshold=self.count_threshold,
+                                        parallel=parallel).reset_index()
+        # use the peaks identified to select trains
+        good_trains = np.unique(tof_data.loc[:,'trainId'].to_numpy())
+        # create an index of good elements
+        idx = tof_data.loc[:, ['trainId', 'pulseIndex']].set_index(['trainId', 'pulseIndex']).index
+        logging.info("Summing good trains ...")
+        # select only trains with a photo-electron detected ("good trains") to do this faster
+        analog_data = -tof.select_trains(by_id[good_trains]).pulse_data(pulse_dim="pulseIndex", parallel=parallel)
+        # select the train-pulses of interest
+        this_tof_data = analog_data.sel(pulse=idx).mean("pulse")
+        # apply an roi
+        if self.roi is not None:
+            this_tof_data = this_tof_data.isel(sample=self.roi)
+
     def setup(self,
               tof: AdqRawChannel,
               scan: Scan=None,
@@ -466,33 +495,23 @@ class TOFAnalogResponse(SerializableMixin):
                 this_tof_data = -tof.pulse_data(pulse_dim="pulseIndex", parallel=parallel).unstack("pulse")
                 logging.info("Averaging over mono settings ...")
                 for k, e in enumerate(scan.positions):
-                    data += [this_tof_data.sel(trainId=scan.positions_train_ids[k]).mean("trainId").mean("pulseIndex").to_numpy()]
+                    d = this_tof_data.sel(trainId=scan.positions_train_ids[k])
+                    if self.roi is not None:
+                        d = d.isel(sample=self.roi)
+                    d = d.mean("trainId").mean("pulseIndex").to_numpy()
+                    data += [d]
             else:
                 # count photo-electrons by histogramming peak positions
                 for tof_part in scan.split_by_steps(tof):
-                    logging.info("Calling pulse_edges for selected trains ...")
-                    tof_data = tof_part.pulse_edges(pulse_dim='pulseIndex', threshold=self.count_threshold, parallel=parallel).reset_index()
-                    good_trains = np.unique(tof_data.loc[:,'trainId'].to_numpy())
-                    idx = tof_data.loc[:, ['trainId', 'pulseIndex']].set_index(['trainId', 'pulseIndex']).index
-                    logging.info("Summing good trains ...")
-                    analog_data = -tof.select_trains(by_id[good_trains]).pulse_data(pulse_dim="pulseIndex", parallel=parallel)
-                    this_tof_data = analog_data.sel(pulse=idx).mean("pulse")
-                    if self.roi is not None:
-                        this_tof_data = this_tof_data.isel(sample=self.roi)
+                    this_tof_data = self._count_photo_electrons(tof_part, parallel=parallel)
                     data += [this_tof_data.to_numpy()]
         else:
             if self.count_threshold is None or self.count_threshold >= 0:
                 this_tof_data = -tof.pulse_data(pulse_dim="pulseIndex", parallel=parallel).mean('pulse')
+                if self.roi is not None:
+                    this_tof_data = this_tof_data.isel(sample=self.roi)
             else:
-                logging.info("Calling pulse_edges ...")
-                tof_data = tof.pulse_edges(pulse_dim='pulseIndex', threshold=self.count_threshold, parallel=parallel).reset_index()
-                good_trains = np.unique(tof_data.loc[:,'trainId'].to_numpy())
-                idx = tof_data.loc[:, ['trainId', 'pulseIndex']].set_index(['trainId', 'pulseIndex']).index
-                logging.info("Summing good trains ...")
-                analog_data = -tof.select_trains(by_id[good_trains]).pulse_data(pulse_dim="pulseIndex", parallel=parallel)
-                this_tof_data = analog_data.sel(pulse=idx).mean("pulse")
-            if self.roi is not None:
-                this_tof_data = this_tof_data.isel(sample=self.roi)
+                this_tof_data = self._count_photo_electrons(tof, parallel=parallel)
             data += [this_tof_data.to_numpy()]
 
         for d in data:

--- a/src/extra/applications/cookiebox_deconvolve.py
+++ b/src/extra/applications/cookiebox_deconvolve.py
@@ -490,7 +490,7 @@ class TOFAnalogResponse(SerializableMixin):
                 idx = tof_data.loc[:, ['trainId', 'pulseIndex']].set_index(['trainId', 'pulseIndex']).index
                 logging.info("Summing good trains ...")
                 analog_data = -tof.select_trains(by_id[good_trains]).pulse_data(pulse_dim="pulseIndex", parallel=parallel)
-                this_tof_data = analog_data.sel(pulse=idx)
+                this_tof_data = analog_data.sel(pulse=idx).mean("pulse")
             if self.roi is not None:
                 this_tof_data = this_tof_data.isel(sample=self.roi)
             data += [this_tof_data.to_numpy()]

--- a/src/extra/applications/cookiebox_deconvolve.py
+++ b/src/extra/applications/cookiebox_deconvolve.py
@@ -470,9 +470,13 @@ class TOFAnalogResponse(SerializableMixin):
             else:
                 # count photo-electrons by histogramming peak positions
                 for k, e in enumerate(scan.positions):
+                    logging.info("Calling pulse_edges for selected trains ...")
                     tof_data = tof.select_trains(by_id[scan.positions_train_ids[k]]).pulse_edges(pulse_dim='pulseIndex', threshold=self.count_threshold, parallel=parallel).reset_index()
-                    this_tof_data, _ = np.histogram(tof_data.edge, bins=bins, weights=-tof_data.amplitude)
-                    this_tof_data = xr.DataArray(this_tof_data, dims=('sample'), coords={'sample': bins[:-1]})
+                    good_trains = np.unique(tof_data.loc[:,'trainId'].to_numpy())
+                    idx = tof_data.loc[:, ['trainId', 'pulseIndex']].set_index(['trainId', 'pulseIndex']).idx
+                    logging.info("Summing good trains ...")
+                    analog_data = -tof.select_trains(by_id[good_trains]).pulse_data(pulse_dim="pulseIndex", parallel=parallel)
+                    this_tof_data = analog_data.sel(pulse=idx)
                 if self.roi is not None:
                     this_tof_data = this_tof_data.isel(sample=self.roi)
                 data += [this_tof_data.to_numpy()]
@@ -480,9 +484,13 @@ class TOFAnalogResponse(SerializableMixin):
             if self.count_threshold is None or self.count_threshold >= 0:
                 this_tof_data = -tof.pulse_data(pulse_dim="pulseIndex", parallel=parallel).mean('pulse')
             else:
+                logging.info("Calling pulse_edges ...")
                 tof_data = tof.pulse_edges(pulse_dim='pulseIndex', threshold=self.count_threshold, parallel=parallel).reset_index()
-                this_tof_data, _ = np.histogram(tof_data.edge, bins=bins, weights=-tof_data.amplitude)
-                this_tof_data = xr.DataArray(this_tof_data, dims=('sample'), coords={'sample': bins[:-1]})
+                good_trains = np.unique(tof_data.loc[:,'trainId'].to_numpy())
+                idx = tof_data.loc[:, ['trainId', 'pulseIndex']].set_index(['trainId', 'pulseIndex']).idx
+                logging.info("Summing good trains ...")
+                analog_data = -tof.select_trains(by_id[good_trains]).pulse_data(pulse_dim="pulseIndex", parallel=parallel)
+                this_tof_data = analog_data.sel(pulse=idx)
             if self.roi is not None:
                 this_tof_data = this_tof_data.isel(sample=self.roi)
             data += [this_tof_data.to_numpy()]

--- a/src/extra/applications/cookiebox_deconvolve.py
+++ b/src/extra/applications/cookiebox_deconvolve.py
@@ -465,6 +465,7 @@ class TOFAnalogResponse(SerializableMixin):
         # apply an roi
         if self.roi is not None:
             this_tof_data = this_tof_data.isel(sample=self.roi)
+        return this_tof_data
 
     def setup(self,
               tof: AdqRawChannel,

--- a/src/extra/applications/cookiebox_deconvolve.py
+++ b/src/extra/applications/cookiebox_deconvolve.py
@@ -469,9 +469,9 @@ class TOFAnalogResponse(SerializableMixin):
                     data += [this_tof_data.sel(trainId=scan.positions_train_ids[k]).mean("trainId").mean("pulseIndex").to_numpy()]
             else:
                 # count photo-electrons by histogramming peak positions
-                for k, e in enumerate(scan.positions):
+                for tof_part in scan.split_by_steps(tof):
                     logging.info("Calling pulse_edges for selected trains ...")
-                    tof_data = tof.select_trains(by_id[scan.positions_train_ids[k]]).pulse_edges(pulse_dim='pulseIndex', threshold=self.count_threshold, parallel=parallel).reset_index()
+                    tof_data = tof_part.pulse_edges(pulse_dim='pulseIndex', threshold=self.count_threshold, parallel=parallel).reset_index()
                     good_trains = np.unique(tof_data.loc[:,'trainId'].to_numpy())
                     idx = tof_data.loc[:, ['trainId', 'pulseIndex']].set_index(['trainId', 'pulseIndex']).index
                     logging.info("Summing good trains ...")

--- a/src/extra/applications/cookiebox_deconvolve.py
+++ b/src/extra/applications/cookiebox_deconvolve.py
@@ -473,13 +473,13 @@ class TOFAnalogResponse(SerializableMixin):
                     logging.info("Calling pulse_edges for selected trains ...")
                     tof_data = tof.select_trains(by_id[scan.positions_train_ids[k]]).pulse_edges(pulse_dim='pulseIndex', threshold=self.count_threshold, parallel=parallel).reset_index()
                     good_trains = np.unique(tof_data.loc[:,'trainId'].to_numpy())
-                    idx = tof_data.loc[:, ['trainId', 'pulseIndex']].set_index(['trainId', 'pulseIndex']).idx
+                    idx = tof_data.loc[:, ['trainId', 'pulseIndex']].set_index(['trainId', 'pulseIndex']).index
                     logging.info("Summing good trains ...")
                     analog_data = -tof.select_trains(by_id[good_trains]).pulse_data(pulse_dim="pulseIndex", parallel=parallel)
-                    this_tof_data = analog_data.sel(pulse=idx)
-                if self.roi is not None:
-                    this_tof_data = this_tof_data.isel(sample=self.roi)
-                data += [this_tof_data.to_numpy()]
+                    this_tof_data = analog_data.sel(pulse=idx).mean("pulse")
+                    if self.roi is not None:
+                        this_tof_data = this_tof_data.isel(sample=self.roi)
+                    data += [this_tof_data.to_numpy()]
         else:
             if self.count_threshold is None or self.count_threshold >= 0:
                 this_tof_data = -tof.pulse_data(pulse_dim="pulseIndex", parallel=parallel).mean('pulse')

--- a/tests/test_applications_cookiebox.py
+++ b/tests/test_applications_cookiebox.py
@@ -441,6 +441,10 @@ def test_deconvolve(mock_sqs_etof_calibration_run, tmp_path):
     tof_response_noscan = TOFAnalogResponse(roi=slice(75, None), n_samples=150)
     tof_response_noscan.setup(tof_channel[0])
 
+    # setup TOFAnalogResponse without Scan and counting of photo-electrons
+    tof_response_noscan_count = TOFAnalogResponse(roi=slice(75, None), n_samples=150, count_threshold=-20)
+    tof_response_noscan_count.setup(tof_channel[0])
+
     # create calibration object to read data in the appropriate format
     energy_axis = np.linspace(965, 1070, 160)
     xgm = XGM(mock_sqs_etof_calibration_run, pulse_energy)


### PR DESCRIPTION
TOFAnalogResponse aligns data from different conditions and averages them to extract the response function of a time-of-flight spectrometer. It can also simply count photo-electrons to obtain the detector response effect, ignoring the spectrometer impact. The latter mode is not very useful, as it disregards part of the response.

In this PR, the method of counting photo-electrons is used to threshold the data, while the analog data collected is still averaged out for the data passing the threshold. This allows this application to operate in very high-noise regimes.