### PR TITLE
Update BadPixels with new bits

### DIFF
--- a/src/extra/calibration/__init__.py
+++ b/src/extra/calibration/__init__.py
@@ -34,6 +34,9 @@ class BadPixels(IntFlag):
     NON_LIN_RESPONSE_REGION  = 1 << 20
     WRONG_GAIN_VALUE         = 1 << 21
     NON_STANDARD_SIZE        = 1 << 22
+    EXPERT_CHOICE            = 1 << 23
+    USER1                    = 1 << 30
+    USER2                    = 1 << 31
 
 
 __all__ = [


### PR DESCRIPTION
Some updates to the `BadPixels` enum as discussed in CAL dev team:

* `EXPERT_CHOICE` for interactive masks set by the operators and experts, e.g. the `BadPixelsManual` 
* Reserved last two bits for arbitrary use labelled `USER1` and `USER2`