### PR TITLE
Improve numerical stability of the deconvolution in TOFAnalogDeconvolution

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,6 +19,7 @@
 Added:
 
 Fixed:
+- [TOFAnalogResponse][extra.applications.TOFAnalogResponse] has improved numerical stability (!538).
 
 Changed:
 

--- a/src/extra/applications/cookiebox_deconvolve.py
+++ b/src/extra/applications/cookiebox_deconvolve.py
@@ -1,6 +1,6 @@
 from typing import Tuple, Union, Optional, List
 from functools import partial
-from scipy.linalg import convolution_matrix
+from scipy.linalg import convolution_matrix, pinvh
 from scipy.signal import find_peaks
 import numpy as np
 import xarray as xr
@@ -79,7 +79,7 @@ def nn_deconvolution(data: np.ndarray, h: np.ndarray, n_iter: int=4000, n_shift:
     I = np.eye(N)
 
     rho = 0.1
-    G = np.linalg.pinv(A.T @ A + rho*I)
+    G = pinvh(A.T @ A + rho*I)
     x = np.copy(b)
     z = np.copy(b)
     u = np.copy(b)
@@ -195,7 +195,7 @@ def tv_deconvolution(data: np.ndarray, h: np.ndarray, Lambda: float=1e-5, n_iter
     # Its proximal operator is tabulated (see Ref. [2], sec. 6.1.1):
     # $\text{prox}_{\tau G} (v) = (I + \tau A^T A)^{-1} (v + \tau A^T b)
     I = np.eye(N)
-    GG = np.linalg.pinv(I + tau*(A.T @ A))
+    GG = pinvh(I + tau*(A.T @ A))
     ATb = np.ascontiguousarray((A.T @ b))
     if nonneg:
         prox_G = lambda v: np.clip(GG @ (v + tau*ATb), a_min=0, a_max=None)
@@ -520,7 +520,11 @@ class TOFAnalogResponse(SerializableMixin):
             this_h /= np.amax(this_h)
             if self.deconvolve:
                 this_t, p = self.estimate_truth(this_h)
-                h_dec = tv_deconvolution(this_h, np.roll(this_t, -p), Lambda=1, nonneg=False)
+                try:
+                    h_dec = tv_deconvolution(this_h, np.roll(this_t, -p), Lambda=1, nonneg=False)
+                except LinAlgError:
+                    logging.warning("Skipping data with singular response function.")
+                    continue
                 h_dec /= np.amax(h_dec)
                 h += [h_dec]
             else:

--- a/src/extra/applications/cookiebox_deconvolve.py
+++ b/src/extra/applications/cookiebox_deconvolve.py
@@ -1,6 +1,6 @@
 from typing import Tuple, Union, Optional, List
 from functools import partial
-from scipy.linalg import convolution_matrix, pinvh, LinAlgError
+from scipy.linalg import convolution_matrix
 from scipy.signal import find_peaks
 import numpy as np
 import xarray as xr
@@ -79,7 +79,7 @@ def nn_deconvolution(data: np.ndarray, h: np.ndarray, n_iter: int=4000, n_shift:
     I = np.eye(N)
 
     rho = 0.1
-    G = pinvh(A.T @ A + rho*I)
+    G = np.linalg.pinv(A.T @ A + rho*I, hermitian=True)
     x = np.copy(b)
     z = np.copy(b)
     u = np.copy(b)
@@ -195,7 +195,7 @@ def tv_deconvolution(data: np.ndarray, h: np.ndarray, Lambda: float=1e-5, n_iter
     # Its proximal operator is tabulated (see Ref. [2], sec. 6.1.1):
     # $\text{prox}_{\tau G} (v) = (I + \tau A^T A)^{-1} (v + \tau A^T b)
     I = np.eye(N)
-    GG = pinvh(I + tau*(A.T @ A))
+    GG = np.linalg.pinv(I + tau*(A.T @ A), hermitian=True)
     ATb = np.ascontiguousarray((A.T @ b))
     if nonneg:
         prox_G = lambda v: np.clip(GG @ (v + tau*ATb), a_min=0, a_max=None)
@@ -522,7 +522,7 @@ class TOFAnalogResponse(SerializableMixin):
                 this_t, p = self.estimate_truth(this_h)
                 try:
                     h_dec = tv_deconvolution(this_h, np.roll(this_t, -p), Lambda=1, nonneg=False)
-                except LinAlgError:
+                except np.linalg.LinAlgError:
                     logging.warning("Skipping data with singular response function.")
                     continue
                 h_dec /= np.amax(h_dec)

--- a/src/extra/applications/cookiebox_deconvolve.py
+++ b/src/extra/applications/cookiebox_deconvolve.py
@@ -1,6 +1,6 @@
 from typing import Tuple, Union, Optional, List
 from functools import partial
-from scipy.linalg import convolution_matrix, pinvh
+from scipy.linalg import convolution_matrix, pinvh, LinAlgError
 from scipy.signal import find_peaks
 import numpy as np
 import xarray as xr

--- a/tests/test_applications_cookiebox.py
+++ b/tests/test_applications_cookiebox.py
@@ -535,6 +535,10 @@ def test_deconvolve(mock_sqs_etof_calibration_run, tmp_path):
     tof_response_count = TOFAnalogResponse(roi=slice(75, None), n_samples=150, count_threshold=-20)
     tof_response_count.setup(tof_channel[0], scan)
 
+    # setup TOFAnalogResponse using deconvolution
+    tof_response_count = TOFAnalogResponse(roi=slice(75, None), n_samples=150, deconvolve=True)
+    tof_response_count.setup(tof_channel[0], scan)
+
     # setup TOFAnalogResponse without Scan
     tof_response_noscan = TOFAnalogResponse(roi=slice(75, None), n_samples=150)
     tof_response_noscan.setup(tof_channel[0])


### PR DESCRIPTION
As part of the deconvolution algorithm, it is necessary to obtain the inverse of a matrix $I + \lambda A^T A$, where $I$ is the identity, $\lambda \in \mathbb{R}$, and $A$ is a square real matrix. So far `pinv` has been used to do that, but this matrix is self-adjoint, so one could improve speed and numerical stability by using `pinvh`, which assumes the upper-triangular part of the matrix equals the lower triangular part (in case of a real matrix).

Additionally, in case of numerical instability when extracting the response function, since there are multiple estimates of the response function that are averaged, if the deconvolution fails in one case, this sample is ignored and the remaining ones are used. This is done by catching a `LinAlgError` when doing the deconvolution.