### PR TITLE
Add support for `juliacall.JlArray` in `imshow2()`

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,7 +21,9 @@ Added:
 Fixed:
 - [TOFAnalogResponse][extra.applications.TOFAnalogResponse] has improved numerical stability (!538).
 
-Changed:
+Fixed:
+- Fixed support for future PythonCall.jl versions in
+  [imshow2()][extra.utils.imshow2] (!547).
 
 ## [2026.1.1]
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,6 +24,8 @@ Fixed:
 Fixed:
 - Fixed support for future PythonCall.jl versions in
   [imshow2()][extra.utils.imshow2] (!547).
+- Fixed reading of the acquisition time for newer Karabacon versions in the
+  [Scantool](extra.components.Scantool) component (!547).
 
 ## [2026.1.1]
 

--- a/src/extra/components/scantool.py
+++ b/src/extra/components/scantool.py
@@ -66,15 +66,17 @@ class Scantool:
         self._scan_type = values["scanEnv.scanType.value"]
         self._motors = [x.decode() for x in get_first_value(active_motors_keys) if len(x) > 0]
 
-        # The acquisition time vector gives the length of each step, unless the
-        # acquisition mode is some kind of 'continuous' in which case only the
-        # first element is used:
-        # - https://git.xfel.eu/karaboDevices/Karabacon/-/blob/bd22d4a69bf7a401856f49920789ef42fda14ad2/src/karabacon/devices/nodes.py#L264
-        # - https://git.xfel.eu/karaboDevices/Karabacon/-/blob/bd22d4a69bf7a401856f49920789ef42fda14ad2/src/karabacon/enums.py#L67
+        # Newer versions store a vector with the acquisition time of each step
+        # (padded with the last element for missing steps). For cscan/tscan
+        # only the first element is used, as the duration of the whole scan:
+        # - https://git.xfel.eu/karaboDevices3/Karabacon/-/blob/f015ea57e2d613f5dfdd2d34355a8f5ffaa10ef5/src/karabacon/Karabacon.py#L636
+        # - https://git.xfel.eu/karaboDevices3/Karabacon/-/blob/f015ea57e2d613f5dfdd2d34355a8f5ffaa10ef5/src/karabacon/Karabacon.py#L972
+        # - https://git.xfel.eu/karaboDevices3/Karabacon/-/blob/f015ea57e2d613f5dfdd2d34355a8f5ffaa10ef5/src/karabacon/Karabacon.py#L1070
         self._acquisition_time = get_first_value(acquisition_time_keys)
         if _isinstance_no_import(self._acquisition_time, "numpy", "ndarray"):
-            if "Continuous" in values["deviceEnv.acquisitionMode.value"]:
-                self._acquisition_time = self._acquisition_time[0]
+            acq_times = self._acquisition_time
+            if self._scan_type in ("cscan", "tscan") or (acq_times == acq_times[0]).all():
+                self._acquisition_time = acq_times[0]
 
         # The deviceEnv.activeMotors property stores the motor aliases,
         # but we can try to get the actual device names from the
@@ -122,8 +124,12 @@ class Scantool:
         return self._scan_type
 
     @property
-    def acquisition_time(self) -> float:
-        """Acquisition time in seconds."""
+    def acquisition_time(self):
+        """Acquisition time in seconds.
+
+        Usually a single number, unless the acquisition time was set per-step in
+        which case it will be an array.
+        """
         return self._acquisition_time
 
     @property

--- a/src/extra/utils/misc.py
+++ b/src/extra/utils/misc.py
@@ -156,13 +156,19 @@ class StepTimer:
         pass
 
 
-def _isinstance_no_import(obj, mod: str, cls: str):
+def _isinstance_no_import(obj, mod: str, cls: str, allow_fail=False):
     """Check if isinstance(obj, mod.cls) without loading mod"""
     m = sys.modules.get(mod)
     if m is None:
         return False
 
-    return isinstance(obj, getattr(m, cls))
+    try:
+        return isinstance(obj, getattr(m, cls))
+    except AttributeError:
+        if allow_fail:
+            return False
+        else:
+            raise
 
 
 def imshow2(image, *args, colorbar=True, lognorm=False, ax=None, **kwargs):
@@ -192,7 +198,8 @@ def imshow2(image, *args, colorbar=True, lognorm=False, ax=None, **kwargs):
     import matplotlib.pyplot as plt
     is_dataarray = _isinstance_no_import(image, "xarray", "DataArray")
 
-    if _isinstance_no_import(image, "juliacall", "ArrayValue"):
+    if (_isinstance_no_import(image, "juliacall", "ArrayValue", allow_fail=True) or \
+        _isinstance_no_import(image, "juliacall", "JlArray")):
         image = np.asarray(image)
 
     # Disable interpolation by default

--- a/tests/test_components_scantool.py
+++ b/tests/test_components_scantool.py
@@ -69,13 +69,25 @@ def test_scantool():
     # Karabacon 3.0.10 renamed the acquisition time again to
     # deviceEnv.acquisitionTimes and data type changed from Double to VectorDouble.
     # Allows defining acq time per step.
-    mock_run_values["deviceEnv.acquisitionMode.value"] = "Continuous"
-    mock_run_values["deviceEnv.acquisitionTimes.value"] = np.ones(1000, dtype=np.uint8)
-    mock_run_values["deviceEnv.acquisitionTimes.value"][0] = 20
     del mock_run_values["acquisitionTime.value"]
 
+    # A vector with equal elements should be collapsed to a single number
+    mock_run_values["deviceEnv.acquisitionTimes.value"] = np.ones(1000)
     scantool = Scantool(mock_run)
-    assert scantool.acquisition_time == 20
+    assert scantool.acquisition_time == 1
+
+    # But a vector with different per-step times should be preserved
+    acq_times = np.ones(1000)
+    acq_times[0] = 20
+    mock_run_values["deviceEnv.acquisitionTimes.value"] = acq_times
+    scantool = Scantool(mock_run)
+    np.testing.assert_array_equal(scantool.acquisition_time, acq_times)
+
+    # Except for cscan/tscan, where only the first element is used
+    for scan_type in ["cscan", "tscan"]:
+        mock_run_values["scanEnv.scanType.value"] = scan_type
+        scantool = Scantool(mock_run)
+        assert scantool.acquisition_time == 20
 
     # Smoke tests
     scantool.info()


### PR DESCRIPTION
The type was renamed in an upcoming PythonCall release.